### PR TITLE
Arm: Adds PID output ranges and arbitrary feedforward for the shoulder

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -112,6 +112,7 @@ public final class Constants {
       public static final double Gearing = 24576/180.0; //TODO confirm values
       public static final double MinimumFeedForwardVoltage = 0.45;
       public static final double MaximumFeedForwardVoltage = 0.75;
+      public static final double MaxPIDOutput = 0.5; //TODO confirm values
     }
 
     public static class ExtenderConstants{
@@ -124,6 +125,7 @@ public final class Constants {
       public static final double ExtenderSafeLimit = MinimumPositionMeters + 0.02; //TODO confirm values
       public static final double RampUpRate = 0.5; //TODO confirm values
       public static final double ToleranceMeters = 0.02; //TODO confirm values
+      public static final double MaxPIDOutput = 0.5; //TODO confirm values
     }
 
     public static class WristConstants{
@@ -137,6 +139,7 @@ public final class Constants {
       public static final double ToleranceDegrees = 0.5; //TODO confirm values
       public static final double MinimumSafeAngleDegrees = 150;
       public static final double MaximumSafeAngleDegrees = 210;
+      public static final double MaxPIDOutput = 0.3;
     }
 
     public static class GripperConstants{

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -51,10 +51,11 @@ public class Arm extends SubsystemBase {
   }
 
   public void setArmTarget(ArmPose armPose) {
-    m_shoulder.updateSafetyZones(armPose, m_extender.getPositionMeters(), m_wrist.getRotation());
+    double extensionMeters = m_extender.getPositionMeters();
+    m_shoulder.updateSafetyZones(armPose, extensionMeters, m_wrist.getRotation());
     m_extender.updateSafetyZones(armPose, m_shoulder.getRotation());
     m_wrist.updateSafetyZones(armPose, m_shoulder.getRotation());
-    m_shoulder.setTargetAngle(armPose.shoulderAngle);
+    m_shoulder.setTargetAngle(armPose.shoulderAngle, extensionMeters);
     m_extender.ExtendToTarget(armPose.extenderPos);
     if (armPose.wristCoordinate == CoordinateType.ArmRelative){
       m_wrist.setTarget(armPose.wristAngle);

--- a/src/main/java/frc/robot/subsystems/arm/Extender.java
+++ b/src/main/java/frc/robot/subsystems/arm/Extender.java
@@ -38,6 +38,7 @@ public class Extender {
         m_SafetyZoneHelper = new SafetyZoneHelper(ExtenderConstants.MinimumPositionMeters, ExtenderConstants.MaximumPositionMeters);
         m_SparkMax.setOpenLoopRampRate(ExtenderConstants.RampUpRate);
         m_SparkMax.setClosedLoopRampRate(ExtenderConstants.RampUpRate);
+        m_SparkMax.getPIDController().setOutputRange(-ExtenderConstants.MaxPIDOutput, ExtenderConstants.MaxPIDOutput);
         Robot.logManager.addNumber("Extender/ExtensionMeters", () -> getPositionMeters());
         Robot.logManager.addNumber("Extender/SparkMaxMeters", () -> m_SparkMax.getEncoder().getPosition());
     }

--- a/src/main/java/frc/robot/subsystems/arm/Shoulder.java
+++ b/src/main/java/frc/robot/subsystems/arm/Shoulder.java
@@ -73,6 +73,7 @@ public class Shoulder {
             initializeSparkMaxEncoder(canSparkMax, getRotation());
             canSparkMax.setOpenLoopRampRate(ShoulderConstants.RampUpRate);
             canSparkMax.setClosedLoopRampRate(ShoulderConstants.RampUpRate);
+            canSparkMax.getPIDController().setOutputRange(-ShoulderConstants.MaxPIDOutput, ShoulderConstants.MaxPIDOutput);
             //open loop = no pid, closed loop = pid
         }
         m_pidTuner = new PIDTuner("ShoulderPID", true, 0.01, 0, 0, this::tunePID);

--- a/src/main/java/frc/robot/subsystems/arm/Shoulder.java
+++ b/src/main/java/frc/robot/subsystems/arm/Shoulder.java
@@ -102,15 +102,17 @@ public class Shoulder {
         }
     }
 
-    public void setTargetAngle(Rotation2d targetAngle) {
+    public void setTargetAngle(Rotation2d targetAngle, double currentExtensionMeters) {
         double targetDegrees = normalize(targetAngle);
+        double feedForwardVoltage = getArbitraryFeedForward(currentExtensionMeters);
         targetDegrees = m_SafetyZoneHelper.getSafeValue(targetDegrees);
         m_targetDegrees = targetDegrees;
-        m_shoulderL_A.getPIDController().setReference(targetDegrees, ControlType.kPosition);
-        m_shoulderL_B.getPIDController().setReference(targetDegrees, ControlType.kPosition);
-        m_shoulderR_A.getPIDController().setReference(targetDegrees, ControlType.kPosition);
-        m_shoulderR_B.getPIDController().setReference(targetDegrees, ControlType.kPosition);
+        m_shoulderL_A.getPIDController().setReference(targetDegrees, ControlType.kPosition, 0, feedForwardVoltage);
+        m_shoulderL_B.getPIDController().setReference(targetDegrees, ControlType.kPosition, 0, feedForwardVoltage);
+        m_shoulderR_A.getPIDController().setReference(targetDegrees, ControlType.kPosition, 0, feedForwardVoltage);
+        m_shoulderR_B.getPIDController().setReference(targetDegrees, ControlType.kPosition, 0, feedForwardVoltage);
     }
+
     public static double normalize(double targetDegrees) {
         targetDegrees %= 360;
         if (targetDegrees <= -230) {
@@ -155,7 +157,9 @@ public class Shoulder {
         return Math.abs(getRotation().getDegrees() - m_targetDegrees) < ShoulderConstants.ToleranceDegrees;
     }
 
-    private double getFeedForward(double currentExtensionMeters) {
+    // We want to add an arbitrary feed forward that applies outside the PID control loop.
+    // https://docs.revrobotics.com/sparkmax/operating-modes/closed-loop-control
+    private double getArbitraryFeedForward(double currentExtensionMeters) {
         double slope = (ShoulderConstants.MaximumFeedForwardVoltage - ShoulderConstants.MinimumFeedForwardVoltage) / 
         (ExtenderConstants.MaximumPositionMeters - ExtenderConstants.MinimumPositionMeters);
         double offset = ShoulderConstants.MinimumFeedForwardVoltage - (ExtenderConstants.MinimumPositionMeters * slope);
@@ -164,14 +168,9 @@ public class Shoulder {
     }
 
     public void periodic(double currentExtensionMeters) {
-        double feedForwardVoltage = getFeedForward(currentExtensionMeters);
-        m_shoulderL_A.getPIDController().setFF(feedForwardVoltage);
-        m_shoulderL_B.getPIDController().setFF(feedForwardVoltage);
-        m_shoulderR_A.getPIDController().setFF(feedForwardVoltage);
-        m_shoulderR_B.getPIDController().setFF(feedForwardVoltage);
         m_pidTuner.tune();
         if (Robot.isSimulation()) {
-            feedForwardVoltage = getFeedForward(kSimExtenderFixedPosition);
+            double feedForwardVoltage = getArbitraryFeedForward(kSimExtenderFixedPosition);
             if(DriverStation.isEnabled() && Double.isFinite(m_targetDegrees)) {
                 double voltage = MathUtil.clamp(m_simPid.calculate(getRotation().getDegrees(), m_targetDegrees), -1, 1) * RobotController.getBatteryVoltage();
                 double voltageWithFeedForward = voltage + feedForwardVoltage;

--- a/src/main/java/frc/robot/subsystems/arm/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/arm/Wrist.java
@@ -46,6 +46,7 @@ public class Wrist {
         initializeSparkMaxEncoder(m_SparkMax, getRotation());
         m_SparkMax.setOpenLoopRampRate(WristConstants.RampUpRate);
         m_SparkMax.setClosedLoopRampRate(WristConstants.RampUpRate);
+        m_SparkMax.getPIDController().setOutputRange(-WristConstants.MaxPIDOutput, WristConstants.MaxPIDOutput);
         Robot.logManager.addNumber("Wrist/Rotation", () -> getRotation().getDegrees());
   
     }


### PR DESCRIPTION
1. When testing last night, we noticed that 0.3 power to the wrist was fast enough and we don't want to go faster that that, so adding an output limit to the PID . Also added an output limit to the shoulder and extender, but that will be for testing and we can still increase/decrease it later. 
2.  Dan thought that maybe we were doing a feedforward inside the PID loop for the shoulder which scales based on the setpoint, when we really want a feedforward that is entirely decided on us based on the shoulder's current rotation in code. See [here](https://docs.revrobotics.com/sparkmax/operating-modes/closed-loop-control) for more information on the two types of feedforward. This changes the code to actually use an arbitrary feedforward. 