### PR TITLE
Adds filters to driver joysticks

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -30,8 +30,8 @@ public final class Constants {
     public static final double RobotLength_in = 22.25;
     public static final double RobotWidth_m = RobotWidth_in / 39.3701;
     public static final double RobotLength_m = RobotLength_in / 39.3701;
-    public static final double MaxRobotSpeed_mps = 2; //4.6 
-    public static final double MaxRobotRotation_radps = 2; //5
+    public static final double MaxRobotSpeed_mps = 4.6; //4.6 
+    public static final double MaxRobotRotation_radps = 3; //5
     public static final int CanIdFrontLeftAngle = 1;
     public static final int CanIdFrontLeftVelocity = 2;
     public static final int CanIdFrontRightAngle = 4;

--- a/src/main/java/frc/robot/commands/BaseJoystickDrive.java
+++ b/src/main/java/frc/robot/commands/BaseJoystickDrive.java
@@ -14,14 +14,14 @@ import frc.robot.subsystems.swerve.SwerveDrive;
 
 public abstract class BaseJoystickDrive extends CommandBase {
 
-  public static boolean UseSlewer = false;
+  public static boolean UseSlewer = true;
 
   protected interface JoystickFilter {
     double get();
   }
 
   protected class JoystickSlewer implements JoystickFilter {
-    SlewRateLimiter m_slewRateLimiter = new SlewRateLimiter(6); // Test for a good value. This is amount of input change in one second, so should allow 0 to full in 1/6 a second
+    SlewRateLimiter m_slewRateLimiter = new SlewRateLimiter(0.2); // Test for a good value. This is amount of input change in one second, so should allow 0 to full in 1/6 a second
     Supplier<Double> m_joystickSupplier;
     
     JoystickSlewer(Supplier<Double> joystickSupplier) {

--- a/src/main/java/frc/robot/commands/BaseJoystickDrive.java
+++ b/src/main/java/frc/robot/commands/BaseJoystickDrive.java
@@ -34,17 +34,29 @@ public abstract class BaseJoystickDrive extends CommandBase {
   }
 
   protected class JoystickLowPassFilter implements JoystickFilter {
-    double lastValue = 0;
+    double lastFilteredValue = 0;
+    final double FilteringConstant = 0.2;
     Supplier<Double> m_joystickSupplier;
 
     JoystickLowPassFilter(Supplier<Double> joystickSupplier) {
       m_joystickSupplier = joystickSupplier;
     }
 
+    /**
+     * Runs a low pass filter on the supplied joystick data
+     * From Dan:
+     * X = Y + (Y-Z) A
+     * Correct formula: X = Y + (Z-Y) A (Josh swapped Z and Y)
+     * X: new filtered value
+     * Y: old filtered value
+     * Z: new unfiltered value
+     * A: filtering Constant
+     */
     public double get() {
-      double newValue = (m_joystickSupplier.get() + lastValue) / 2;
-      lastValue = newValue;
-      return newValue;
+      double newValue = m_joystickSupplier.get();
+      double newFilteredValue = lastFilteredValue + ((newValue - lastFilteredValue) * FilteringConstant);
+      lastFilteredValue = newFilteredValue;
+      return newFilteredValue;
     }
   }
 

--- a/src/main/java/frc/robot/commands/BaseJoystickDrive.java
+++ b/src/main/java/frc/robot/commands/BaseJoystickDrive.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import java.util.function.Supplier;
+
+import com.chaos131.gamepads.Gamepad;
+
+import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.swerve.SwerveDrive;
+
+public abstract class BaseJoystickDrive extends CommandBase {
+
+  public static boolean UseSlewer = false;
+
+  protected interface JoystickFilter {
+    double get();
+  }
+
+  protected class JoystickSlewer implements JoystickFilter {
+    SlewRateLimiter m_slewRateLimiter = new SlewRateLimiter(6); // Test for a good value. This is amount of input change in one second, so should allow 0 to full in 1/6 a second
+    Supplier<Double> m_joystickSupplier;
+    
+    JoystickSlewer(Supplier<Double> joystickSupplier) {
+      m_joystickSupplier = joystickSupplier;
+    }
+
+    public double get() {
+      return m_slewRateLimiter.calculate(m_joystickSupplier.get());
+    }
+  }
+
+  protected class JoystickLowPassFilter implements JoystickFilter {
+    double lastValue = 0;
+    Supplier<Double> m_joystickSupplier;
+
+    JoystickLowPassFilter(Supplier<Double> joystickSupplier) {
+      m_joystickSupplier = joystickSupplier;
+    }
+
+    public double get() {
+      double newValue = (m_joystickSupplier.get() + lastValue) / 2;
+      lastValue = newValue;
+      return newValue;
+    }
+  }
+
+  protected final SwerveDrive m_swerveDrive;
+  protected final Gamepad m_driverController;
+  protected final JoystickFilter m_slewedLeftX;
+  protected final JoystickFilter m_slewedLeftY;
+  protected final JoystickFilter m_slewedRightX;
+  protected final JoystickFilter m_slewedRightY;
+
+  /** Shares some code for all joystick drives */
+  public BaseJoystickDrive(SwerveDrive swerveDrive, Gamepad driverController) {
+    m_swerveDrive = swerveDrive;
+    m_driverController = driverController;
+    if (UseSlewer) {
+      m_slewedLeftX = new JoystickSlewer(() -> driverController.getLeftX());
+      m_slewedLeftY = new JoystickSlewer(() -> driverController.getLeftY());
+      m_slewedRightX = new JoystickSlewer(() -> driverController.getRightX());
+      m_slewedRightY = new JoystickSlewer(() -> driverController.getRightY());
+    } else {
+      m_slewedLeftX = new JoystickLowPassFilter(() -> driverController.getLeftX());
+      m_slewedLeftY = new JoystickLowPassFilter(() -> driverController.getLeftY());
+      m_slewedRightX = new JoystickLowPassFilter(() -> driverController.getRightX());
+      m_slewedRightY = new JoystickLowPassFilter(() -> driverController.getRightY());
+    }
+
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(swerveDrive);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    m_swerveDrive.stop();
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/DriverRelativeAngleDrive.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeAngleDrive.java
@@ -7,20 +7,12 @@ package frc.robot.commands;
 import com.chaos131.gamepads.Gamepad;
 
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
-public class DriverRelativeAngleDrive extends CommandBase {
-  protected SwerveDrive m_swerveDrive;
-  protected Gamepad m_driverController;
+public class DriverRelativeAngleDrive extends BaseJoystickDrive {
   /** Creates a new DriverRelativeAngleDrive. */
   public DriverRelativeAngleDrive(SwerveDrive swerveDrive, Gamepad driverController) {
-    m_swerveDrive = swerveDrive;
-    m_driverController = driverController;
-
-    // Use addRequirements() here to declare subsystem dependencies.
-    addRequirements(swerveDrive);
+    super(swerveDrive, driverController);
   }
 
   // Called when the command is initially scheduled.
@@ -32,8 +24,8 @@ public class DriverRelativeAngleDrive extends CommandBase {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double xMetersPerSecond = m_driverController.getLeftY();
-    double yMetersPerSecond = -m_driverController.getLeftX();
+    double xMetersPerSecond = m_slewedLeftY.get();
+    double yMetersPerSecond = -m_slewedLeftX.get();
     Rotation2d rightAngle = getTargetRotation();
     double rightMagnitude = getTargetMagnitude();
     m_swerveDrive.moveFieldRelativeAngle(xMetersPerSecond, yMetersPerSecond, rightAngle, rightMagnitude);

--- a/src/main/java/frc/robot/commands/DriverRelativeDrive.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeDrive.java
@@ -6,44 +6,20 @@ package frc.robot.commands;
 
 import com.chaos131.gamepads.Gamepad;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
-public class DriverRelativeDrive extends CommandBase {
-  private SwerveDrive m_swerveDrive;
-  private Gamepad m_driverController;
+public class DriverRelativeDrive extends BaseJoystickDrive {
   /** Creates a new FieldRelativeDrive. */
   public DriverRelativeDrive(SwerveDrive swerveDrive, Gamepad driverController) {
-    m_swerveDrive = swerveDrive;
-    m_driverController = driverController;
-
-    // Use addRequirements() here to declare subsystem dependencies.
-    addRequirements(swerveDrive);
+    super(swerveDrive, driverController);
   }
-
-  // Called when the command is initially scheduled.
-  @Override
-  public void initialize() {}
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double xMetersPerSecond = -m_driverController.getLeftY();
-    double yMetersPerSecond = -m_driverController.getLeftX();
+    double xMetersPerSecond = -m_slewedLeftY.get();
+    double yMetersPerSecond = -m_slewedLeftX.get();
     double omegaRadiansPerSecond = -m_driverController.getRightX();
     m_swerveDrive.moveFieldRelative(xMetersPerSecond, yMetersPerSecond, omegaRadiansPerSecond);
-  }
-
-  // Called once the command ends or is interrupted.
-  @Override
-  public void end(boolean interrupted) {
-    m_swerveDrive.stop();
-  }
-
-  // Returns true when the command should end.
-  @Override
-  public boolean isFinished() {
-    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/DriverRelativeSetAngleDrive.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeSetAngleDrive.java
@@ -7,7 +7,6 @@ package frc.robot.commands;
 import com.chaos131.gamepads.Gamepad;
 
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
 public class DriverRelativeSetAngleDrive extends DriverRelativeAngleDrive {

--- a/src/main/java/frc/robot/commands/RobotRelativeDrive.java
+++ b/src/main/java/frc/robot/commands/RobotRelativeDrive.java
@@ -6,44 +6,20 @@ package frc.robot.commands;
 
 import com.chaos131.gamepads.Gamepad;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
-public class RobotRelativeDrive extends CommandBase {
-  private SwerveDrive m_swerveDrive;
-  private Gamepad m_driverController;
+public class RobotRelativeDrive extends BaseJoystickDrive {
   /** Creates a new RobotRelativeDrive. */
   public RobotRelativeDrive(SwerveDrive swerveDrive, Gamepad driverController) {
-    m_swerveDrive = swerveDrive;
-    m_driverController = driverController;
-
-    // Use addRequirements() here to declare subsystem dependencies.
-    addRequirements(swerveDrive);
+    super(swerveDrive, driverController);
   }
-
-  // Called when the command is initially scheduled.
-  @Override
-  public void initialize() { }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double xMetersPerSecond = -m_driverController.getLeftY();
-    double yMetersPerSecond = -m_driverController.getLeftX();
+    double xMetersPerSecond = -m_slewedLeftY.get();
+    double yMetersPerSecond = -m_slewedLeftX.get();
     double omegaRadiansPerSecond = -m_driverController.getRightX();
     m_swerveDrive.moveRobotRelative(xMetersPerSecond, yMetersPerSecond, omegaRadiansPerSecond);
-  }
-
-  // Called once the command ends or is interrupted.
-  @Override
-  public void end(boolean interrupted) {
-    m_swerveDrive.stop();
-  }
-
-  // Returns true when the command should end.
-  @Override
-  public boolean isFinished() {
-    return false;
   }
 }


### PR DESCRIPTION
Adds two types of filters to driver translation, to help avoid tipping from sudden input changes. 
Dan requested LowPassFilter (I would need to double check with him that I implemented it like he wanted) but I also saw there was an existing filter that exists to help with our use case:
https://docs.wpilib.org/en/stable/docs/software/advanced-controls/filters/slew-rate-limiter.html
