### PR TITLE
Updates operator to go to target poses, while driver still finishes them

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -130,7 +130,7 @@ public class RobotContainer {
       
 
     // // Practice score commands - should move targets to operator
-    m_driver.rightTrigger().whileTrue(new Score(m_arm, () -> m_nextPrepPose, () -> m_nextScorePose));
+    m_driver.rightTrigger().whileTrue(new Score(m_arm, () -> m_nextPrepPose, () -> m_nextScorePose, 1));
 
     m_driver.leftBumper().whileTrue(new SwerveXMode(m_swerveDrive));
     m_driver.leftTrigger().whileTrue(new StartEndCommand(()-> SwerveDrive.SpeedModifier = 0.5, ()-> SwerveDrive.SpeedModifier = 1));
@@ -184,7 +184,7 @@ public class RobotContainer {
     m_operator.leftTrigger().whileTrue(new InstantCommand(()->m_arm.setGripperMode(GripperMode.unGrip), m_arm).repeatedly());
 
     // temp. Replace with LEDS when working 
-    m_operator.back().whileTrue(new Score(m_arm, () -> m_nextPrepPose, () -> m_nextScorePose));
+    m_operator.back().whileTrue(new Score(m_arm, () -> m_nextPrepPose, () -> m_nextScorePose, 1));
 
     // // Cones
     // m_operator.povDown().whileTrue(new MoveArm(m_arm, ArmPose.LowScorePose).repeatedly());

--- a/src/main/java/frc/robot/commands/DefaultArmCommand.java
+++ b/src/main/java/frc/robot/commands/DefaultArmCommand.java
@@ -15,12 +15,10 @@ import frc.robot.subsystems.arm.Gripper.GripperMode;
 public class DefaultArmCommand extends CommandBase {
   
   private Arm m_arm;
-  private Gamepad m_tester;
 
   /** Creates a new DefaultArmCommand. */
-  public DefaultArmCommand(Arm arm, Gamepad tester) {
+  public DefaultArmCommand(Arm arm) {
     m_arm = arm;
-    m_tester = tester;
     addRequirements(arm);
   }
 

--- a/src/main/java/frc/robot/commands/Score.java
+++ b/src/main/java/frc/robot/commands/Score.java
@@ -9,29 +9,33 @@ import java.util.function.Supplier;
 import javax.sql.CommonDataSource;
 
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.arm.ArmPose;
+import frc.robot.subsystems.arm.Gripper.GripperMode;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
 // information, see:
 // https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class Score extends SequentialCommandGroup {
   /** Creates a new Score. */
-  public Score(Arm arm, Supplier<ArmPose> prepPoseSupplier, Supplier<ArmPose> targetPoseSupplier) {
+  public Score(Arm arm, Supplier<ArmPose> prepPoseSupplier, Supplier<ArmPose> targetPoseSupplier, int endWaitSeconds) {
     if (prepPoseSupplier != null){
       addCommands(new MoveArm(arm, prepPoseSupplier));
     }
     Command goToScorePosition = new MoveArm(arm, targetPoseSupplier);
-    Command release = new UnGrip(arm).withTimeout(1);
+    Command release = new InstantCommand(() -> arm.setGripperMode(GripperMode.slowUngrip));
     addCommands(goToScorePosition, release);
     if (prepPoseSupplier != null){
       addCommands(new MoveArm(arm, prepPoseSupplier));
     }
+    addCommands(new WaitCommand(endWaitSeconds)); // wait at the end to make sure the piece is out before the gripper stops
   }
 
   public Score(Arm arm, Supplier<ArmPose> targetPoseSupplier) {
-    this (arm, null, targetPoseSupplier);
+    this (arm, null, targetPoseSupplier, 1);
   }
 
   public Score(Arm arm, ArmPose pose) {


### PR DESCRIPTION
Creates the commands such that the operator moves the arms into the prep position (prep position is target position for cubes), but the driver will still execute the score command.

Also made it so the tester controller doesn't constant throw errors unless we enable it.