### PR TITLE
Drive upgrades

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -24,6 +24,7 @@ import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.DefaultArmCommand;
 import frc.robot.commands.DriveToTarget;
 import frc.robot.commands.DriverRelativeDrive;
+import frc.robot.commands.DriverRelativeSetAngleDrive;
 import frc.robot.commands.Grip;
 import frc.robot.commands.MoveArm;
 import frc.robot.commands.MoveExtender;
@@ -46,6 +47,7 @@ import frc.robot.subsystems.arm.Gripper;
 import frc.robot.subsystems.arm.Gripper.GripperMode;
 import frc.robot.subsystems.swerve.DrivePose;
 import frc.robot.subsystems.swerve.SwerveDrive;
+import frc.robot.util.DriveDirection;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -160,31 +162,31 @@ public class RobotContainer {
   private void driverControls() {
     Command driverRelativeDrive = new DriverRelativeDrive(m_swerveDrive, m_driver);
     m_swerveDrive.setDefaultCommand(driverRelativeDrive);
+    var slowModeCommand = new StartEndCommand(()-> SwerveDrive.SpeedModifier = 0.4, ()-> SwerveDrive.SpeedModifier = 1);
+
     m_driver.start().onTrue(driverRelativeDrive);
     m_driver.back().onTrue(new RobotRelativeDrive(m_swerveDrive, m_driver));
 
-    m_driver.povUp().onTrue(new ResetHeading(m_swerveDrive, ResetHeading.Direction.Up));
-    m_driver.povDown().onTrue(new ResetHeading(m_swerveDrive, ResetHeading.Direction.Down));
-    m_driver.povLeft().onTrue(new ResetHeading(m_swerveDrive, ResetHeading.Direction.Left));
-    m_driver.povRight().onTrue(new ResetHeading(m_swerveDrive, ResetHeading.Direction.Right));
+    m_driver.povUp().onTrue(new ResetHeading(m_swerveDrive, DriveDirection.Up));
+    m_driver.povDown().onTrue(new ResetHeading(m_swerveDrive, DriveDirection.Down));
+    m_driver.povLeft().onTrue(new ResetHeading(m_swerveDrive, DriveDirection.Left));
+    m_driver.povRight().onTrue(new ResetHeading(m_swerveDrive, DriveDirection.Right));
       
     m_driver.leftBumper().whileTrue(new SwerveXMode(m_swerveDrive));
-    m_driver.leftTrigger().whileTrue(new StartEndCommand(()-> SwerveDrive.SpeedModifier = 0.5, ()-> SwerveDrive.SpeedModifier = 1));
-    // NOTE: Driver Right Trigger is used in operaterControls()
+    m_driver.leftTrigger().whileTrue(slowModeCommand);
 
-    //m_driver.leftStick().whileTrue(new InstantCommand(()->m_arm.setGripperMode(GripperMode.grip)).andThen(new MoveArm(m_arm, ArmPose.IntakeBack).repeatedly()));
-    // m_driver.y().onTrue(new DriverRelativeAngleDrive(m_swerveDrive, m_driver));
-   
-    // m_driver.leftBumper().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, Rotation2d.fromDegrees(90), 1.0));
-    // m_driver.leftTrigger().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, Rotation2d.fromDegrees(-90), 1.0));
-    //m_gripperMutex.setDefaultCommand(new InstantCommand( () -> m_arm.setGripperMode(GripperMode.hold), m_gripperMutex ));
-    //m_driver.rightBumper().whileTrue(new InstantCommand( () -> m_arm.setGripperMode(GripperMode.grip) ));
-    //m_driver.rightTrigger().whileTrue(new InstantCommand( () -> m_arm.setGripperMode(GripperMode.unGrip) ));
+    m_driver.rightBumper().whileTrue(slowModeCommand);
+    m_driver.rightTrigger().whileTrue(new RunCommand(() -> m_gripper.setGripperMode(GripperMode.grip), m_gripper));
+
+    m_driver.a().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Down, 1.0));
+    m_driver.b().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Right, 1.0));
+    m_driver.x().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Left, 1.0));
+    m_driver.y().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Up, 1.0));
   }
 
   private void operaterControls(){
     m_arm.setDefaultCommand(new DefaultArmCommand(m_arm, m_tester));
-    Command defaultGripCommand = new InstantCommand( () -> m_gripper.setGripperMode(GripperMode.hold),m_gripper);
+    Command defaultGripCommand = new InstantCommand(() -> m_gripper.setGripperMode(GripperMode.hold), m_gripper);
     m_gripper.setDefaultCommand(defaultGripCommand);
 
     // Pose selection

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -178,6 +178,9 @@ public class RobotContainer {
     m_driver.rightBumper().whileTrue(slowModeCommand);
     m_driver.rightTrigger().whileTrue(new RunCommand(() -> m_gripper.setGripperMode(GripperMode.grip), m_gripper));
 
+    m_driver.leftStick().whileTrue(slowModeCommand);
+    m_driver.rightStick().whileTrue(slowModeCommand);
+
     m_driver.a().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Down, 1.0));
     m_driver.b().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Right, 1.0));
     m_driver.x().whileTrue(new DriverRelativeSetAngleDrive(m_swerveDrive, m_driver, DriveDirection.Left, 1.0));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -23,6 +23,7 @@ import frc.robot.Constants.ArmConstants.ExtenderConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.DefaultArmCommand;
 import frc.robot.commands.DriveToTarget;
+import frc.robot.commands.DriveToTargetWithLimelights;
 import frc.robot.commands.DriverRelativeDrive;
 import frc.robot.commands.DriverRelativeSetAngleDrive;
 import frc.robot.commands.Grip;
@@ -58,9 +59,9 @@ import frc.robot.util.DriveDirection;
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
 
-  private SwerveDrive m_swerveDrive = new SwerveDrive();
   private Limelight m_limelightLeft = new Limelight("limelight-left");
   private Limelight m_limelightRight = new Limelight ("limelight-right");
+  private SwerveDrive m_swerveDrive = new SwerveDrive(m_limelightLeft, m_limelightRight);
   //private Limelight m_Limelight2 = new Limelight("limeLight2");
   public final Gripper m_gripper = new Gripper();
   public final Arm m_arm = new Arm(m_gripper);
@@ -96,7 +97,10 @@ public class RobotContainer {
   public RobotContainer() {
     // Register auto commands
     autoBuilder.registerCommand("resetPosition", (parsedCommand) -> ResetPose.createAutoCommand(parsedCommand, m_swerveDrive));
+    autoBuilder.registerCommand("resetPositionWithLimelights", (parsedCommand) -> new InstantCommand(() -> m_swerveDrive.updatePoseFromLimelights(), m_swerveDrive));
     autoBuilder.registerCommand("drive", (parsedCommand) -> DriveToTarget.createAutoCommand(parsedCommand, m_swerveDrive));
+    autoBuilder.registerCommand("xMode", (parsedCommand) -> new SwerveXMode(m_swerveDrive));
+    autoBuilder.registerCommand("driveWithLimelights", (parsedCommand) -> DriveToTargetWithLimelights.createAutoCommand(parsedCommand, m_swerveDrive));
     autoBuilder.registerCommand("moveArm", (parsedCommand) -> MoveArm.createAutoCommand(parsedCommand, m_arm));
     autoBuilder.registerCommand("driveAndMoveArm", (parsedCommand) -> AutoComboCommands.driveAndMoveArm(parsedCommand, m_swerveDrive, m_arm));
     autoBuilder.registerCommand("driveAndGrip", (parsedCommand) -> AutoComboCommands.driveAndGrip(parsedCommand, m_swerveDrive, m_gripper));
@@ -108,35 +112,8 @@ public class RobotContainer {
 
   
   public void robotPeriodic(){
-    // Pose2d LLLeftPose = m_limelightLeft.getPose();
-    // Pose2d LLRightPose = m_limelightRight.getPose();
-    // if (LLLeftPose != null && LLRightPose != null){
-    //   // System.out.println(LLLeftPose.toString() + LLRightPose.toString()); 
-    //   double leftDistance = Math.abs(m_limelightLeft.getTargetXDistancePixels());
-    //   double rightDistance = Math.abs(m_limelightRight.getTargetXDistancePixels());
-    //   if (leftDistance < rightDistance){
-    //     m_swerveDrive.resetPose(LLLeftPose);
-    //   }
-    //   else{
-    //     m_swerveDrive.resetPose(LLRightPose);
-    //   }
-      
-    // }
-    // else if (LLRightPose != null){
-    //   // System.out.println(LLRightPose.toString()); 
-
-    //   m_swerveDrive.resetPose(LLRightPose);
-    // }
-    // else if (LLLeftPose != null){
-    //   // System.out.println(LLLeftPose.toString()); 
-
-    //   m_swerveDrive.resetPose(LLLeftPose);
-    // }
-
     SmartDashboard.putString("OperatorMode", m_currentArmMode.name());
     SmartDashboard.putString("OperatorModeColor", m_currentArmMode.getColor());
-
-
   }
 
   public void delayedRobotInit(){

--- a/src/main/java/frc/robot/commands/AutoBalanceDrive.java
+++ b/src/main/java/frc/robot/commands/AutoBalanceDrive.java
@@ -1,0 +1,44 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import com.chaos131.pid.PIDTuner;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.swerve.SwerveDrive;
+import frc.robot.util.DashboardNumber;
+import frc.robot.util.DriveDirection;
+
+public class AutoBalanceDrive extends CommandBase {
+  private static PIDController pid = new PIDController(0.1, 0.0, 0.0);
+  public static PIDTuner PIDTuner = new PIDTuner("AutoBalance/PIDTuner", true, pid);
+  private static DashboardNumber MaxSpeed = new DashboardNumber("AutoBalance/MaxPercentPower", 0.5, (newSpeed) -> {});
+  private static DashboardNumber AngleTolerance = new DashboardNumber("AutoBalance/AngleTolerance", 5, (newTolerance) -> {});
+  SwerveDrive m_swerveDrive;
+
+  public AutoBalanceDrive(SwerveDrive swerveDrive) {
+    m_swerveDrive = swerveDrive;
+    addRequirements(swerveDrive);
+  }
+
+  @Override
+  public void initialize() {
+    pid.reset();
+    pid.setSetpoint(0);
+  }
+
+  @Override
+  public void execute() {
+    var pitchDegrees = m_swerveDrive.GetPitch().getDegrees();
+    if(Math.abs(pitchDegrees) < AngleTolerance.get()) {
+      m_swerveDrive.swerveXMode();
+    } else {
+      var speedX = MathUtil.clamp(pid.calculate(m_swerveDrive.GetPitch().getDegrees()), -MaxSpeed.get(), MaxSpeed.get());
+      m_swerveDrive.moveFieldRelativeAngle(speedX, 0, DriveDirection.Towards.getAllianceAngle(), 1.0);
+    }
+  }
+}

--- a/src/main/java/frc/robot/commands/DriveToTarget.java
+++ b/src/main/java/frc/robot/commands/DriveToTarget.java
@@ -18,7 +18,7 @@ import frc.robot.subsystems.swerve.DrivePose;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
 public class DriveToTarget extends CommandBase {
-  private SwerveDrive m_swerveDrive;
+  protected SwerveDrive m_swerveDrive;
   private Supplier<Pose2d> m_poseSupplier;
   private double m_translationTolerance;
 

--- a/src/main/java/frc/robot/commands/DriveToTargetWithLimelights.java
+++ b/src/main/java/frc/robot/commands/DriveToTargetWithLimelights.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import com.chaos131.auto.ParsedCommand;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.robot.commands.auto.AutoUtil;
+import frc.robot.subsystems.swerve.SwerveDrive;
+
+public class DriveToTargetWithLimelights extends DriveToTarget {
+
+    /** Creates a new DriveToTarget. */
+  public DriveToTargetWithLimelights(SwerveDrive swerveDrive, Pose2d pose, double translationTolerance) {
+    super(swerveDrive, pose, translationTolerance);
+  }
+
+  public static Command createAutoCommand(ParsedCommand parsedCommand, SwerveDrive swerveDrive) {
+    double translationTolerance = AutoUtil.getTranslationTolerance(parsedCommand);
+    Pose2d pose = AutoUtil.getDrivePose(parsedCommand);
+    if(pose == null) {
+      return new InstantCommand();
+    }
+    return new DriveToTargetWithLimelights(swerveDrive, pose, translationTolerance);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_swerveDrive.updatePoseFromLimelights();
+    super.initialize();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    m_swerveDrive.updatePoseFromLimelights();
+    super.execute();
+  }
+
+}

--- a/src/main/java/frc/robot/commands/DriveToTargetWithLimelights.java
+++ b/src/main/java/frc/robot/commands/DriveToTargetWithLimelights.java
@@ -4,6 +4,8 @@
 
 package frc.robot.commands;
 
+import java.util.function.Supplier;
+
 import com.chaos131.auto.ParsedCommand;
 
 import edu.wpi.first.math.geometry.Pose2d;
@@ -15,8 +17,8 @@ import frc.robot.subsystems.swerve.SwerveDrive;
 public class DriveToTargetWithLimelights extends DriveToTarget {
 
     /** Creates a new DriveToTarget. */
-  public DriveToTargetWithLimelights(SwerveDrive swerveDrive, Pose2d pose, double translationTolerance) {
-    super(swerveDrive, pose, translationTolerance);
+  public DriveToTargetWithLimelights(SwerveDrive swerveDrive, Supplier<Pose2d> poseSupplier, double translationTolerance) {
+    super(swerveDrive, poseSupplier, translationTolerance);
   }
 
   public static Command createAutoCommand(ParsedCommand parsedCommand, SwerveDrive swerveDrive) {
@@ -25,7 +27,7 @@ public class DriveToTargetWithLimelights extends DriveToTarget {
     if(pose == null) {
       return new InstantCommand();
     }
-    return new DriveToTargetWithLimelights(swerveDrive, pose, translationTolerance);
+    return new DriveToTargetWithLimelights(swerveDrive, () -> pose, translationTolerance);
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/commands/DriverRelativeAngleDrive.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeAngleDrive.java
@@ -24,7 +24,7 @@ public class DriverRelativeAngleDrive extends BaseJoystickDrive {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double xMetersPerSecond = m_slewedLeftY.get();
+    double xMetersPerSecond = -m_slewedLeftY.get();
     double yMetersPerSecond = -m_slewedLeftX.get();
     Rotation2d rightAngle = getTargetRotation();
     double rightMagnitude = getTargetMagnitude();

--- a/src/main/java/frc/robot/commands/DriverRelativeSetAngleDrive.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeSetAngleDrive.java
@@ -8,16 +8,17 @@ import com.chaos131.gamepads.Gamepad;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.robot.subsystems.swerve.SwerveDrive;
+import frc.robot.util.DriveDirection;
 
 public class DriverRelativeSetAngleDrive extends DriverRelativeAngleDrive {
   /** Creates a new DriverRelativeSetAngleDrive. */
   double m_magnitude;
-  Rotation2d m_angle;
+  DriveDirection m_direction;
 
-  public DriverRelativeSetAngleDrive(SwerveDrive swervedrive, Gamepad driverController, Rotation2d angle, double magnitude) {
+  public DriverRelativeSetAngleDrive(SwerveDrive swervedrive, Gamepad driverController, DriveDirection direction, double magnitude) {
     super(swervedrive, driverController);
     m_magnitude = magnitude;
-    m_angle = angle;
+    m_direction = direction;
   }
 
   @Override
@@ -27,6 +28,6 @@ public class DriverRelativeSetAngleDrive extends DriverRelativeAngleDrive {
 
   @Override
   protected Rotation2d getTargetRotation() {
-    return m_angle;
+    return m_direction.getAllianceAngle();
   }
 }

--- a/src/main/java/frc/robot/commands/ResetHeading.java
+++ b/src/main/java/frc/robot/commands/ResetHeading.java
@@ -4,25 +4,16 @@
 
 package frc.robot.commands;
 
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.swerve.SwerveDrive;
+import frc.robot.util.DriveDirection;
 
 public class ResetHeading extends CommandBase {
 
-  public enum Direction {
-    Up,
-    Down,
-    Left,
-    Right
-  }
-
   /** Creates a new ResetHeading. */
   private SwerveDrive m_SwerveDrive;
-  private Direction m_direction;
-  public ResetHeading(SwerveDrive swervedrive, Direction direction) {
+  private DriveDirection m_direction;
+  public ResetHeading(SwerveDrive swervedrive, DriveDirection direction) {
     m_SwerveDrive = swervedrive;
     m_direction = direction;
     addRequirements(swervedrive);
@@ -32,23 +23,7 @@ public class ResetHeading extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    boolean BlueAlliance = (DriverStation.getAlliance() == Alliance.Blue);
-    double heading = 0;
-    switch (m_direction){
-      case Up:
-        heading = BlueAlliance ? 180 : 0;
-        break;
-      case Down:
-        heading = BlueAlliance ? 0 : 180;
-        break;
-      case Left:
-        heading = BlueAlliance ? 270 : 90;
-        break;
-      case Right:
-        heading = BlueAlliance ? 90 : 270;
-        break;
-    }
-    m_SwerveDrive.resetHeading(Rotation2d.fromDegrees(heading));
+    m_SwerveDrive.resetHeading(m_direction.getAllianceAngle());
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
@@ -29,6 +29,7 @@ import frc.robot.Robot;
 import frc.robot.Constants.SwerveConstants;
 import frc.robot.commands.RecalibrateModules;
 import frc.robot.logging.LogManager;
+import frc.robot.subsystems.Limelight;
 
 public class SwerveDrive extends SubsystemBase {
 
@@ -54,9 +55,15 @@ public class SwerveDrive extends SubsystemBase {
   private PIDTuner m_moduleVelocityPIDTuner;
   private PIDTuner m_moduleAnglePIDTuner;
   private double m_driveToTargetTolerance = Constants.DriveToTargetTolerance;
+  
+  private Limelight m_limelightLeft;
+  private Limelight m_limelightRight;
 
   /** Creates a new SwerveDrive. */
-  public SwerveDrive() {
+  public SwerveDrive(Limelight limelightLeft, Limelight limelightRight) {
+    m_limelightLeft = limelightLeft;
+    m_limelightRight = limelightRight;
+
     Translation2d frontLeftTranslation = new Translation2d(SwerveConstants.RobotLength_m / 2, SwerveConstants.RobotWidth_m / 2);
     Translation2d frontRightTranslation = new Translation2d(SwerveConstants.RobotLength_m / 2,-SwerveConstants.RobotWidth_m / 2);
     Translation2d backLeftTranslation = new Translation2d(-SwerveConstants.RobotLength_m / 2, SwerveConstants.RobotWidth_m / 2);
@@ -339,6 +346,33 @@ public class SwerveDrive extends SubsystemBase {
 
   public void setDriveTranslationTolerance(double tolerance) {
     m_driveToTargetTolerance = tolerance;
+  }
+
+  public void updatePoseFromLimelights() {
+    Pose2d LLLeftPose = m_limelightLeft.getPose();
+    Pose2d LLRightPose = m_limelightRight.getPose();
+    if (LLLeftPose != null && LLRightPose != null){
+      // System.out.println(LLLeftPose.toString() + LLRightPose.toString()); 
+      double leftDistance = Math.abs(m_limelightLeft.getTargetXDistancePixels());
+      double rightDistance = Math.abs(m_limelightRight.getTargetXDistancePixels());
+      if (leftDistance < rightDistance){
+        resetPose(LLLeftPose);
+      }
+      else{
+        resetPose(LLRightPose);
+      }
+      
+    }
+    else if (LLRightPose != null){
+      // System.out.println(LLRightPose.toString()); 
+
+      resetPose(LLRightPose);
+    }
+    else if (LLLeftPose != null){
+      // System.out.println(LLLeftPose.toString()); 
+
+      resetPose(LLLeftPose);
+    }
   }
 }
 // “I love polyester.” -Kenny

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
@@ -300,6 +300,7 @@ public class SwerveDrive extends SubsystemBase {
     updateModuleOnField(m_backLeft, robotPose, "BL");
     updateModuleOnField(m_backRight, robotPose, "BR");
     SmartDashboard.putNumber("gyro_angle", getGyroRotation().getDegrees());
+    SmartDashboard.putNumber("gyro_pitch", GetPitch().getDegrees());
     m_XPidTuner.tune();
     m_YPidTuner.tune();
     m_AnglePidTuner.tune();
@@ -373,6 +374,10 @@ public class SwerveDrive extends SubsystemBase {
 
       resetPose(LLLeftPose);
     }
+  }
+
+  public Rotation2d GetPitch() {
+    return Rotation2d.fromDegrees(m_gyro.getPitch());
   }
 }
 // “I love polyester.” -Kenny

--- a/src/main/java/frc/robot/util/DriveDirection.java
+++ b/src/main/java/frc/robot/util/DriveDirection.java
@@ -9,9 +9,13 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 
 public enum DriveDirection {
-    Up(0, 180),
-    Down(180, 0),
+    /** Away from the driver */
+    Away(0, 180),
+    /** Towards the driver */
+    Towards(180, 0),
+    /** To the driver's left */
     Left(90, 270),
+    /** To the driver's right */
     Right(270, 90);
 
     private Rotation2d m_redAngle;

--- a/src/main/java/frc/robot/util/DriveDirection.java
+++ b/src/main/java/frc/robot/util/DriveDirection.java
@@ -1,0 +1,28 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.util;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+
+public enum DriveDirection {
+    Up(0, 180),
+    Down(180, 0),
+    Left(90, 270),
+    Right(270, 90);
+
+    private Rotation2d m_redAngle;
+    private Rotation2d m_blueAngle;
+
+    private DriveDirection(double redAngle, double blueAngle) {
+        m_redAngle = Rotation2d.fromDegrees(redAngle);
+        m_blueAngle = Rotation2d.fromDegrees(blueAngle);
+    }
+
+    public Rotation2d getAllianceAngle() {
+        return DriverStation.getAlliance() == Alliance.Red ? m_redAngle : m_blueAngle;
+    }
+}


### PR DESCRIPTION
Driver controls (tested in sim)

- Adds the set angle drives to the driver controller for a/b/x/y and it takes into consideration the current alliance
- Reduced the slow speed value to 0.4 (from 0.5) and added it to the 4 buttons you asked for

Auto/auto balancing (NOT tested in sim)

- Added a DriveWithLimelights command, where we only update the swerve odometry from limelight data in this command. We can use this to try driving onto the balance point with limelight data - we might need to add the limelight filtering tomorrow, but figured that might go better with your help
- Added an AutoBalance command that use the same drive as the A button on the driver (so robot will face the drivers) and uses the robot's pitch to drive up or down the slope (using a dashboard-tunable PID, max speed, and tolerance). If within the tolerance, the swerve drive goes into x mode
- Added the above two commands, a resetPositionFromLimelight command, and an xMode command to the auto scripts