### PR TITLE
Adds constants to disable dashboard logging when not in debug mode and adds a Coach's tab to put values that should always log to the dashboard.

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -19,6 +19,16 @@ import com.fazecast.jSerialComm.SerialPort;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+
+  public static final double UpdateFrequency_Hz = 50;
+
+  public static class DebugConstants {
+    public static final boolean IsDebugMode = false;
+    public static final boolean EnableDriveDebug = IsDebugMode;
+    public static final boolean EnableArmDebug = IsDebugMode;
+    public static final boolean EnableGripperDebug = IsDebugMode;
+  }
+
   public static class OperatorConstants {
     public static final int kDriverControllerPort = 0;
     public static final int kOperatorControllerPort = 1;
@@ -26,6 +36,9 @@ public final class Constants {
   }
 
   public static class SwerveConstants {
+    public static final double MaxTranslationPIDSpeedPercent = 1.0;
+    public static final double DriveToTargetTolerance = 0.03;
+    public static final double AnglePIDTolerance = 3.0;
     public static final double RobotWidth_in = 21.25;
     public static final double RobotLength_in = 22.25;
     public static final double RobotWidth_m = RobotWidth_in / 39.3701;
@@ -60,11 +73,6 @@ public final class Constants {
     public static final double FieldWidth_m = 8.02;
     public static final double FieldLength_m = 16.54;
   }
-
-  public static final double UpdateFrequency_Hz = 50;
-  public static final double MaxTranslationPIDSpeedPercent = 1.0;
-  public static final double DriveToTargetTolerance = 0.03;
-  public static final double AnglePIDTolerance = 3.0;
 
   public static class ArmConstants{
     public static class ShoulderConstants{

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.logging.LogManager;
 import frc.robot.util.DashboardNumber;
 
@@ -23,7 +24,7 @@ import frc.robot.util.DashboardNumber;
  */
 public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
-  public static final LogManager logManager = new LogManager(true);
+  public static final LogManager logManager = new LogManager();
 
   private RobotContainer m_robotContainer;
 
@@ -36,7 +37,7 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
-    logManager.addNumber("GameState", () -> robotMode());
+    logManager.addNumber("GameState", DebugConstants.IsDebugMode, () -> robotMode());
     logManager.writeHeaders();
     new Timer().schedule(new TimerTask() {
       @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import com.chaos131.gamepads.Gamepad;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -114,6 +115,7 @@ public class RobotContainer {
     autoBuilder.registerCommand("score", (parsedCommand) -> Score.createAutoCommand(parsedCommand, m_arm, m_gripper));
     // Configure the trigger bindings
     configureBindings();
+    addCoachTabDashboardValues();
   }
 
   public void robotPeriodic(){
@@ -123,14 +125,18 @@ public class RobotContainer {
   public void delayedRobotInit(){
     m_swerveDrive.recalibrateModules();
     m_arm.recalibrateSensors();
-    addCoachTabDashboardValues();
   }
 
   public void addCoachTabDashboardValues() {
     var coachTab = Shuffleboard.getTab("Coach");
+    m_arm.addCoachTabDashboardValues(coachTab);
+    m_gripper.addCoachTabDashboardValues(coachTab);
+    m_swerveDrive.addCoachTabDashboardValues(coachTab);
     coachTab.addString("OperatorMode", () -> m_currentArmMode.name());
     coachTab.addString("OperatorModeColor", () -> m_currentArmMode.getColor());
-    coachTab.addBoolean("HasPiece?", () -> m_gripper.hasPiece());
+    coachTab.addString("AllianceColor", () -> DriverStation.getAlliance().name());
+    coachTab.addString("LeftLimelight", () -> "http://10.1.31.11:5800");
+    coachTab.addString("RightLimelight", () -> "http://10.1.31.23:5800");
     // TODO: Figure out the values the coach/drive team want displayed on the dashboard always
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,6 +13,7 @@ import com.chaos131.gamepads.Gamepad;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
@@ -23,7 +24,9 @@ import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.ArmConstants.ExtenderConstants;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.OperatorConstants;
+import frc.robot.Constants.SwerveConstants;
 import frc.robot.commands.AutoBalanceDrive;
 import frc.robot.commands.DefaultArmCommand;
 import frc.robot.commands.DriveToTarget;
@@ -76,8 +79,6 @@ public class RobotContainer {
 
   private final Gamepad m_operator = new Gamepad(OperatorConstants.kOperatorControllerPort);
 
-  private final Gamepad m_tester = new Gamepad(OperatorConstants.kTesterControllerPort);
-
   private enum ArmMode{ 
     Cube("#8a2be2"),
     Cone("#f9e909"),
@@ -115,17 +116,24 @@ public class RobotContainer {
     configureBindings();
   }
 
-  
   public void robotPeriodic(){
-    SmartDashboard.putString("OperatorMode", m_currentArmMode.name());
-    SmartDashboard.putString("OperatorModeColor", m_currentArmMode.getColor());
     AutoBalanceDrive.PIDTuner.tune();
   }
 
   public void delayedRobotInit(){
     m_swerveDrive.recalibrateModules();
     m_arm.recalibrateSensors();
+    addCoachTabDashboardValues();
   }
+
+  public void addCoachTabDashboardValues() {
+    var coachTab = Shuffleboard.getTab("Coach");
+    coachTab.addString("OperatorMode", () -> m_currentArmMode.name());
+    coachTab.addString("OperatorModeColor", () -> m_currentArmMode.getColor());
+    coachTab.addBoolean("HasPiece?", () -> m_gripper.hasPiece());
+    // TODO: Figure out the values the coach/drive team want displayed on the dashboard always
+  }
+
   /**
    * Use this method to define your trigger->command mappings. Triggers can be created via the
    * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with an arbitrary
@@ -172,7 +180,7 @@ public class RobotContainer {
   }
 
   private void operaterControls(){
-    m_arm.setDefaultCommand(new DefaultArmCommand(m_arm, m_tester));
+    m_arm.setDefaultCommand(new DefaultArmCommand(m_arm));
     Command defaultGripCommand = new InstantCommand(() -> m_gripper.setGripperMode(GripperMode.hold), m_gripper);
     m_gripper.setDefaultCommand(defaultGripCommand);
 
@@ -209,8 +217,10 @@ public class RobotContainer {
     m_operator.rightTrigger().and(isCubeMode).whileTrue(intake(ArmPose.IntakeCubeBack));
     
     // test
-    m_operator.start().whileTrue(new ShuffleBoardPose(m_arm, "start").repeatedly());
-    m_operator.back().whileTrue(new ShuffleBoardPose(m_arm, "back").repeatedly());
+    if (DebugConstants.EnableArmDebug) {
+      m_operator.start().whileTrue(new ShuffleBoardPose(m_arm, "start").repeatedly());
+      m_operator.back().whileTrue(new ShuffleBoardPose(m_arm, "back").repeatedly());
+    }
   }
 
   private Command scorePrep(ArmPose pose) {
@@ -223,44 +233,54 @@ public class RobotContainer {
 
   private void dashboardCommands() {
     // created a test command on Shuffleboard for each known pose
-    ArmPose.forAllPoses((String poseName, ArmPose pose) -> SmartDashboard.putData("Set Arm Pose/" + poseName, new MoveArm(m_arm, pose).repeatedly()));
-    DrivePose.DrivePoses.forEach((String poseName, DrivePose pose) -> {
-      SmartDashboard.putData("Drive To Target/" + pose.m_redName, new DriveToTarget(m_swerveDrive, pose.m_redPose, Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
-      SmartDashboard.putData("Drive To Target/" + pose.m_blueName, new DriveToTarget(m_swerveDrive, pose.m_bluePose, Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
-    });
+    if (DebugConstants.EnableArmDebug) {
+      ArmPose.forAllPoses((String poseName, ArmPose pose) -> SmartDashboard.putData("Set Arm Pose/" + poseName, new MoveArm(m_arm, pose).repeatedly()));
+    }
+    if (DebugConstants.EnableDriveDebug) {
+      DrivePose.DrivePoses.forEach((String poseName, DrivePose pose) -> {
+        SmartDashboard.putData("Drive To Target/" + pose.m_redName, new DriveToTarget(m_swerveDrive, pose.m_redPose, SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
+        SmartDashboard.putData("Drive To Target/" + pose.m_blueName, new DriveToTarget(m_swerveDrive, pose.m_bluePose, SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
+      });
+    }
   }
 
   private void testCommands() {
-    // m_tester.a().whileTrue(new MoveExtender(m_arm, ExtenderConstants.MinimumPositionMeters + 0.02));
-    // m_tester.x().whileTrue(new MoveExtender(m_arm, 1.1));
-    // m_tester.y().whileTrue(new MoveExtender(m_arm, ExtenderConstants.MaximumPositionMeters - 0.02));
-    // m_tester.b().whileTrue(new TestWrist(m_arm, m_tester));
-    // m_tester.back().whileTrue(new Grip(m_gripper));
-    // m_tester.start().whileTrue(new UnGrip(m_gripper));
-    // m_tester.povUp().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(0)));
-    // m_tester.povRight().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-45)));
-    // m_tester.povDown().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-90)));
-    // m_tester.povLeft().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-135)));
-    // m_tester.rightTrigger().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(90)));
-    // m_tester.rightBumper().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(270)));
-    // m_tester.leftBumper().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(180)));
-    // m_tester.a().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.grip),m_gripper));
-    // m_tester.b().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.hold),m_gripper));
-    // m_tester.y().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.unGrip),m_gripper));
-    // m_tester.povUp().whileTrue(new ShuffleBoardPose(m_arm, "povUp").repeatedly());
-    // m_tester.povDown().whileTrue(new ShuffleBoardPose(m_arm, "povDown").repeatedly());
-    // m_tester.rightTrigger().whileTrue(new AutoBalanceDrive(m_swerveDrive));
-    // m_tester.rightBumper().whileTrue(
+    // Don't make the tester controller and commands if not in debug mode
+    if(!DebugConstants.IsDebugMode) {
+      return;
+    }
+
+    Gamepad testController = new Gamepad(OperatorConstants.kTesterControllerPort);
+    // testController.a().whileTrue(new MoveExtender(m_arm, ExtenderConstants.MinimumPositionMeters + 0.02));
+    // testController.x().whileTrue(new MoveExtender(m_arm, 1.1));
+    // testController.y().whileTrue(new MoveExtender(m_arm, ExtenderConstants.MaximumPositionMeters - 0.02));
+    // testController.b().whileTrue(new TestWrist(m_arm, testController));
+    // testController.back().whileTrue(new Grip(m_gripper));
+    // testController.start().whileTrue(new UnGrip(m_gripper));
+    // testController.povUp().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(0)));
+    // testController.povRight().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-45)));
+    // testController.povDown().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-90)));
+    // testController.povLeft().whileTrue(new MoveShoulder(m_arm, Rotation2d.fromDegrees(-135)));
+    // testController.rightTrigger().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(90)));
+    // testController.rightBumper().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(270)));
+    // testController.leftBumper().whileTrue(new MoveWrist(m_arm, Rotation2d.fromDegrees(180)));
+    // testController.a().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.grip),m_gripper));
+    // testController.b().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.hold),m_gripper));
+    // testController.y().whileTrue(new RunCommand( () -> m_gripper.setGripperMode(GripperMode.unGrip),m_gripper));
+    // testController.povUp().whileTrue(new ShuffleBoardPose(m_arm, "povUp").repeatedly());
+    // testController.povDown().whileTrue(new ShuffleBoardPose(m_arm, "povDown").repeatedly());
+    // testController.rightTrigger().whileTrue(new AutoBalanceDrive(m_swerveDrive));
+    // testController.rightBumper().whileTrue(
     //   new DriveToTargetWithLimelights(m_swerveDrive, () -> DrivePose.Balance.getCurrentAlliancePose(), Constants.DriveToTargetTolerance)
     //   .andThen(new SwerveXMode(m_swerveDrive))
     // );
     var xStart = 8;
     var yStart = 4;
-    m_tester.start().onTrue(new ResetPose(m_swerveDrive, new Pose2d(xStart, yStart, Rotation2d.fromDegrees(0))));
-    m_tester.b().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart, yStart, Rotation2d.fromDegrees(0)), Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
-    m_tester.y().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart + 1, yStart, Rotation2d.fromDegrees(90)), Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
-    m_tester.a().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart - 1, yStart, Rotation2d.fromDegrees(270)), Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
-    m_tester.x().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart, yStart + 1, Rotation2d.fromDegrees(180)), Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent));
+    testController.start().onTrue(new ResetPose(m_swerveDrive, new Pose2d(xStart, yStart, Rotation2d.fromDegrees(0))));
+    testController.b().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart, yStart, Rotation2d.fromDegrees(0)), SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
+    testController.y().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart + 1, yStart, Rotation2d.fromDegrees(90)), SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
+    testController.a().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart - 1, yStart, Rotation2d.fromDegrees(270)), SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
+    testController.x().whileTrue(new DriveToTarget(m_swerveDrive, new Pose2d(xStart, yStart + 1, Rotation2d.fromDegrees(180)), SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent));
 
   }
 
@@ -275,9 +295,11 @@ public class RobotContainer {
   }
 
   public void addSmartDashboard() {
-    SmartDashboard.putNumber("Driver Left X", m_driver.getLeftX());
-    SmartDashboard.putNumber("Driver Right X", m_driver.getRightX());
-    SmartDashboard.putNumber("Driver Left Y", m_driver.getLeftY());
-    SmartDashboard.putNumber("Driver Right Y", m_driver.getRightY());
+    if (DebugConstants.EnableDriveDebug) {
+      SmartDashboard.putNumber("Driver Left X", m_driver.getLeftX());
+      SmartDashboard.putNumber("Driver Right X", m_driver.getRightX());
+      SmartDashboard.putNumber("Driver Left Y", m_driver.getLeftY());
+      SmartDashboard.putNumber("Driver Right Y", m_driver.getRightY());
+    }
   }
 }

--- a/src/main/java/frc/robot/commands/AutoBalanceDrive.java
+++ b/src/main/java/frc/robot/commands/AutoBalanceDrive.java
@@ -9,15 +9,16 @@ import com.chaos131.pid.PIDTuner;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.subsystems.swerve.SwerveDrive;
 import frc.robot.util.DashboardNumber;
 import frc.robot.util.DriveDirection;
 
 public class AutoBalanceDrive extends CommandBase {
   private static PIDController pid = new PIDController(0.1, 0.0, 0.0);
-  public static PIDTuner PIDTuner = new PIDTuner("AutoBalance/PIDTuner", true, pid);
-  private static DashboardNumber MaxSpeed = new DashboardNumber("AutoBalance/MaxPercentPower", 0.5, (newSpeed) -> {});
-  private static DashboardNumber AngleTolerance = new DashboardNumber("AutoBalance/AngleTolerance", 5, (newTolerance) -> {});
+  public static PIDTuner PIDTuner = new PIDTuner("AutoBalance/PID_Tuner", DebugConstants.EnableDriveDebug, pid);
+  private static DashboardNumber MaxSpeed = new DashboardNumber("AutoBalance/MaxPercentPower", 0.5, DebugConstants.EnableDriveDebug, (newSpeed) -> {});
+  private static DashboardNumber AngleTolerance = new DashboardNumber("AutoBalance/AngleTolerance", 5, DebugConstants.EnableDriveDebug, (newTolerance) -> {});
   SwerveDrive m_swerveDrive;
 
   public AutoBalanceDrive(SwerveDrive swerveDrive) {
@@ -33,11 +34,11 @@ public class AutoBalanceDrive extends CommandBase {
 
   @Override
   public void execute() {
-    var pitchDegrees = m_swerveDrive.GetPitch().getDegrees();
+    var pitchDegrees = m_swerveDrive.getPitch().getDegrees();
     if(Math.abs(pitchDegrees) < AngleTolerance.get()) {
       m_swerveDrive.swerveXMode();
     } else {
-      var speedX = MathUtil.clamp(pid.calculate(m_swerveDrive.GetPitch().getDegrees()), -MaxSpeed.get(), MaxSpeed.get());
+      var speedX = MathUtil.clamp(pid.calculate(m_swerveDrive.getPitch().getDegrees()), -MaxSpeed.get(), MaxSpeed.get());
       m_swerveDrive.moveFieldRelativeAngle(speedX, 0, DriveDirection.Towards.getAllianceAngle(), 1.0);
     }
   }

--- a/src/main/java/frc/robot/commands/BaseJoystickDrive.java
+++ b/src/main/java/frc/robot/commands/BaseJoystickDrive.java
@@ -10,6 +10,7 @@ import com.chaos131.gamepads.Gamepad;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.SwerveConstants;
 import frc.robot.subsystems.swerve.SwerveDrive;
 import frc.robot.util.DashboardNumber;
@@ -25,7 +26,7 @@ public abstract class BaseJoystickDrive extends CommandBase {
     Supplier<Double> m_joystickSupplier;
 
     JoystickSlewer(Supplier<Double> joystickSupplier) {
-      new DashboardNumber("Driver/SlewRateLimit", SwerveConstants.SlewRateLimit, (newLimit) -> {
+      new DashboardNumber("Driver/SlewRateLimit", SwerveConstants.SlewRateLimit, DebugConstants.EnableDriveDebug, (newLimit) -> {
         m_slewRateLimiter = new SlewRateLimiter(newLimit);
       });
       m_joystickSupplier = joystickSupplier;

--- a/src/main/java/frc/robot/commands/DefaultArmCommand.java
+++ b/src/main/java/frc/robot/commands/DefaultArmCommand.java
@@ -4,23 +4,17 @@
 
 package frc.robot.commands;
 
-import com.chaos131.gamepads.Gamepad;
-
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.arm.ArmPose;
-import frc.robot.subsystems.arm.Gripper;
-import frc.robot.subsystems.arm.Gripper.GripperMode;
 
 public class DefaultArmCommand extends CommandBase {
   
   private Arm m_arm;
-  private Gamepad m_tester;
 
   /** Creates a new DefaultArmCommand. */
-  public DefaultArmCommand(Arm arm, Gamepad tester) {
+  public DefaultArmCommand(Arm arm) {
     m_arm = arm;
-    m_tester = tester;
     addRequirements(arm);
   }
 

--- a/src/main/java/frc/robot/commands/DriveToTarget.java
+++ b/src/main/java/frc/robot/commands/DriveToTarget.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import frc.robot.Constants;
+import frc.robot.Constants.SwerveConstants;
 import frc.robot.commands.auto.AutoUtil;
 import frc.robot.subsystems.swerve.DrivePose;
 import frc.robot.subsystems.swerve.SwerveDrive;
@@ -57,7 +58,7 @@ public class DriveToTarget extends CommandBase {
         return null;
       }
       return closestPose;
-    }, Constants.DriveToTargetTolerance, Constants.MaxTranslationPIDSpeedPercent);
+    }, SwerveConstants.DriveToTargetTolerance, SwerveConstants.MaxTranslationPIDSpeedPercent);
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/commands/RobotRelativeDrive.java
+++ b/src/main/java/frc/robot/commands/RobotRelativeDrive.java
@@ -6,21 +6,12 @@ package frc.robot.commands;
 
 import com.chaos131.gamepads.Gamepad;
 
-import frc.robot.Robot;
 import frc.robot.subsystems.swerve.SwerveDrive;
 
 public class RobotRelativeDrive extends BaseJoystickDrive {
   /** Creates a new RobotRelativeDrive. */
   public RobotRelativeDrive(SwerveDrive swerveDrive, Gamepad driverController) {
     super(swerveDrive, driverController);
-    Robot.logManager.addNumber("Driver/left_x", () -> driverController.getLeftX());
-    Robot.logManager.addNumber("Driver/left_y", () -> driverController.getLeftY());
-    Robot.logManager.addNumber("Driver/right_x", () -> driverController.getRightX());
-    Robot.logManager.addNumber("Driver/right_y", () -> driverController.getRightY());
-    Robot.logManager.addNumber("Driver/slewed_left_x", () -> m_slewedLeftX.get());
-    Robot.logManager.addNumber("Driver/slewed_left_y", () -> m_slewedLeftY.get());
-    Robot.logManager.addNumber("Driver/slewed_right_x", () -> m_slewedRightX.get());
-    Robot.logManager.addNumber("Driver/slewed_right_y", () -> m_slewedRightY.get());
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/auto/AutoUtil.java
+++ b/src/main/java/frc/robot/commands/auto/AutoUtil.java
@@ -5,6 +5,7 @@ import com.chaos131.auto.ParsedCommand;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import frc.robot.Constants;
+import frc.robot.Constants.SwerveConstants;
 import frc.robot.subsystems.arm.ArmPose;
 import frc.robot.subsystems.arm.Wrist.CoordinateType;
 import frc.robot.subsystems.swerve.DrivePose;
@@ -23,7 +24,7 @@ public class AutoUtil {
      * @param parsedCommand the auto script step
      */
     public static double getTranslationTolerance(ParsedCommand parsedCommand) {
-        return AutoUtil.ParseDouble(parsedCommand.getArgument("translationTolerance"), Constants.DriveToTargetTolerance);
+        return AutoUtil.ParseDouble(parsedCommand.getArgument("translationTolerance"), SwerveConstants.DriveToTargetTolerance);
     }
     
     /**
@@ -31,7 +32,7 @@ public class AutoUtil {
      * @param parsedCommand the auto script step
      */
     public static double getMaxPercentSpeed(ParsedCommand parsedCommand) {
-        return AutoUtil.ParseDouble(parsedCommand.getArgument("maxPercentSpeed"), Constants.MaxTranslationPIDSpeedPercent);
+        return AutoUtil.ParseDouble(parsedCommand.getArgument("maxPercentSpeed"), SwerveConstants.MaxTranslationPIDSpeedPercent);
     }
 
     /**

--- a/src/main/java/frc/robot/logging/LogManager.java
+++ b/src/main/java/frc/robot/logging/LogManager.java
@@ -13,46 +13,44 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 
 /** Manages the logs recorded into the .csv file, stored on a flash drive on the robot*/
 public class LogManager {
-    private boolean m_willLogShuffleBoard;
     private ShuffleboardTab m_shuffleboardTab;
     private List<String> m_headers = new ArrayList<String>();
     private Map<String, Supplier<String>> m_suppliers = new HashMap<String, Supplier<String>>();
     private LoggingThread m_loggingThread;
 
-    public LogManager(boolean willLogShuffleBoard) {
+    public LogManager() {
         m_loggingThread = new LoggingThread();
         m_shuffleboardTab = Shuffleboard.getTab("Logging");
-        m_willLogShuffleBoard = willLogShuffleBoard;
-        addNumber("timeMs", () -> Robot.getCurrentTimeMs());
+        addNumber("timeMs", DebugConstants.IsDebugMode, () -> Robot.getCurrentTimeMs());
     }
 
-    public void addBoolean(String title, BooleanSupplier valueSupplier) {
+    public void addBoolean(String title, boolean willLogShuffleboard, BooleanSupplier valueSupplier) {
         m_headers.add(title);
         m_suppliers.put(title, () -> String.valueOf(valueSupplier.getAsBoolean()));
-        if (m_willLogShuffleBoard) {
+        if (willLogShuffleboard) {
             m_shuffleboardTab.addBoolean(title, valueSupplier);
         }
     }
 
-    public void addNumber(String title, DoubleSupplier valueSupplier) {
+    public void addNumber(String title, boolean willLogShuffleboard, DoubleSupplier valueSupplier) {
         m_headers.add(title);
         m_suppliers.put(title, () -> String.valueOf(valueSupplier.getAsDouble()));
-        if (m_willLogShuffleBoard) {
+        if (willLogShuffleboard) {
             m_shuffleboardTab.addNumber(title, valueSupplier);
         }
     }
 
-    public void addString(String title, Supplier<String> valueSupplier) {
+    public void addString(String title, boolean willLogShuffleboard, Supplier<String> valueSupplier) {
         m_headers.add(title);
         m_suppliers.put(title, valueSupplier);
-        if (m_willLogShuffleBoard) {
+        if (willLogShuffleboard) {
             m_shuffleboardTab.addString(title, valueSupplier);
         }
     }

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.ArmConstants.ExtenderConstants;
 import frc.robot.Constants.ArmConstants.WristConstants;
 import frc.robot.subsystems.arm.Gripper.GripperMode;
@@ -25,16 +26,11 @@ public class Arm extends SubsystemBase {
     m_extender = new Extender();
     m_wrist = new Wrist();
     m_gripper = gripper;
+    Robot.logManager.addBoolean("Arm/AtTarget", DebugConstants.EnableArmDebug, () -> reachedTarget());
   }
 
   @Override
   public void periodic() {
-    SmartDashboard.putNumber("Arm/ShoulderRotation", m_shoulder.getRotation().getDegrees());
-    SmartDashboard.putNumber("Arm/ExtenderPosition", m_extender.getPositionMeters());
-    SmartDashboard.putNumber("Arm/WristRotation", m_wrist.getRotation().getDegrees());
-    SmartDashboard.putString("Arm/Grippermode", m_gripper.getGripperMode().name());
-    SmartDashboard.putBoolean("Arm/AtTarget", reachedTarget());
-    SmartDashboard.putNumber("Arm/ShoulderDegreesFromStowed", getShoulderDegreesFromStowed());
     m_shoulder.periodic(m_extender.getPositionMeters());
     m_extender.periodic();
     m_wrist.periodic();
@@ -73,7 +69,9 @@ public class Arm extends SubsystemBase {
       armPose.wristAngle.getDegrees(), 
       0
     };
-    SmartDashboard.putNumberArray("Arm/TargetState", targetState);
+    if (DebugConstants.EnableArmDebug) {
+      SmartDashboard.putNumberArray("Arm/TargetState", targetState);
+    }
     double extensionMeters = m_extender.getPositionMeters();
     double normalizedCurrentAngle = Shoulder.normalize(m_shoulder.getRotation());
     double normalizedTargetAngle = Shoulder.normalize(armPose.shoulderAngle);
@@ -135,10 +133,6 @@ public class Arm extends SubsystemBase {
     m_shoulder.recalibrateSensors();
     m_extender.recalibrateSensors();
     m_wrist.recalibrateSensors();
-  }
-
-  public double getShoulderDegreesFromStowed() {
-    return Math.abs(m_shoulder.getRotation().plus(Rotation2d.fromDegrees(90)).getDegrees()); 
   }
 }
 

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -6,6 +6,8 @@
 package frc.robot.subsystems.arm;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
@@ -27,6 +29,12 @@ public class Arm extends SubsystemBase {
     m_wrist = new Wrist();
     m_gripper = gripper;
     Robot.logManager.addBoolean("Arm/AtTarget", DebugConstants.EnableArmDebug, () -> reachedTarget());
+  }
+  
+  public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+    m_shoulder.addCoachTabDashboardValues(coachTab);
+    m_extender.addCoachTabDashboardValues(coachTab);
+    m_wrist.addCoachTabDashboardValues(coachTab);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/arm/Extender.java
+++ b/src/main/java/frc/robot/subsystems/arm/Extender.java
@@ -17,6 +17,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.ArmConstants.ExtenderConstants;
 import frc.robot.Constants.ArmConstants.ShoulderConstants;
 import frc.robot.util.DashboardNumber;
@@ -36,38 +37,39 @@ public class Extender {
         m_sparkMax = new CANSparkMax(ExtenderConstants.CanIdExtender, MotorType.kBrushless);
         m_sparkMax.setInverted(true);
         m_sparkMax.setIdleMode(IdleMode.kBrake);
-        m_pidTuner = new PIDTuner("ExtenderPID", true, 80, 0, 0, this::tunePID);
+        m_pidTuner = new PIDTuner("Extender/PID_Tuner", DebugConstants.EnableArmDebug, 80, 0, 0, this::tunePID);
         m_linearPot = m_sparkMax.getAnalog(Mode.kAbsolute);
         m_linearPot.setPositionConversionFactor(ExtenderConstants.LinearPotConversionFactor);
-        new DashboardNumber("Extender/EncoderConversionFactor", ExtenderConstants.SparkMaxEncoderConversionFactor, (newConversionFactor) -> {
+        new DashboardNumber("Extender/EncoderConversionFactor", ExtenderConstants.SparkMaxEncoderConversionFactor, DebugConstants.EnableArmDebug, (newConversionFactor) -> {
             m_sparkMax.getEncoder().setPositionConversionFactor(newConversionFactor);
             recalibrateSensors();
         });
         m_SafetyZoneHelper = new SafetyZoneHelper(ExtenderConstants.MinimumPositionMeters, ExtenderConstants.MaximumPositionMeters);
         // m_sparkMax.setOpenLoopRampRate(ExtenderConstants.RampUpRate);
         // m_sparkMax.setClosedLoopRampRate(ExtenderConstants.RampUpRate);
-        new DashboardNumber("Extender/RampUprate", ExtenderConstants.RampUpRate, (newValue) -> {
+        new DashboardNumber("Extender/RampUprate", ExtenderConstants.RampUpRate, DebugConstants.EnableArmDebug, (newValue) -> {
             m_sparkMax.setOpenLoopRampRate(newValue);
             m_sparkMax.setClosedLoopRampRate(newValue);
         });
         m_sparkMax.getPIDController().setOutputRange(-ExtenderConstants.MaxPIDOutput, ExtenderConstants.MaxPIDOutput);
-        new DashboardNumber("extender/stallLimit", m_stallLimit, (newValue) -> {
+        new DashboardNumber("Extender/stallLimit", m_stallLimit, DebugConstants.EnableArmDebug, (newValue) -> {
             int stallLimit = (int)((double) newValue);
             updateCurrentLimit(stallLimit, m_freeLimit, m_limitRPM);
         });
-        new DashboardNumber("extender/freeLimit", m_freeLimit, (newValue) -> {
+        new DashboardNumber("Extender/freeLimit", m_freeLimit, DebugConstants.EnableArmDebug, (newValue) -> {
             int freeLimit = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, freeLimit, m_limitRPM);
         });
-        new DashboardNumber("extender/limitRPM", m_limitRPM, (newValue) -> {
+        new DashboardNumber("Extender/limitRPM", m_limitRPM, DebugConstants.EnableArmDebug, (newValue) -> {
             int limitRPM = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, m_freeLimit, limitRPM);
         });
         m_sparkMax.burnFlash();
-        Robot.logManager.addNumber("Extender/SparkMaxMeters", () -> m_sparkMax.getEncoder().getPosition());
-        Robot.logManager.addNumber("Extender/AppliedOutput", () -> m_sparkMax.getAppliedOutput());
-        Robot.logManager.addNumber("Extender/MotorTemperature_C", () -> m_sparkMax.getMotorTemperature());
-        Robot.logManager.addNumber("Extender/OutputCurrent", () -> m_sparkMax.getOutputCurrent());
+        Robot.logManager.addNumber("Extender/Extension_m", DebugConstants.EnableArmDebug, () -> getPositionMeters());
+        Robot.logManager.addNumber("Extender/SparkMaxMeters", DebugConstants.EnableArmDebug, () -> m_sparkMax.getEncoder().getPosition());
+        Robot.logManager.addNumber("Extender/AppliedOutput", DebugConstants.EnableArmDebug, () -> m_sparkMax.getAppliedOutput());
+        Robot.logManager.addNumber("Extender/MotorTemperature_C", DebugConstants.EnableArmDebug, () -> m_sparkMax.getMotorTemperature());
+        Robot.logManager.addNumber("Extender/OutputCurrent", DebugConstants.EnableArmDebug, () -> m_sparkMax.getOutputCurrent());
 
 
     }

--- a/src/main/java/frc/robot/subsystems/arm/Extender.java
+++ b/src/main/java/frc/robot/subsystems/arm/Extender.java
@@ -15,6 +15,7 @@ import com.revrobotics.SparkMaxAnalogSensor.Mode;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
 import frc.robot.Constants.DebugConstants;
@@ -70,8 +71,11 @@ public class Extender {
         Robot.logManager.addNumber("Extender/AppliedOutput", DebugConstants.EnableArmDebug, () -> m_sparkMax.getAppliedOutput());
         Robot.logManager.addNumber("Extender/MotorTemperature_C", DebugConstants.EnableArmDebug, () -> m_sparkMax.getMotorTemperature());
         Robot.logManager.addNumber("Extender/OutputCurrent", DebugConstants.EnableArmDebug, () -> m_sparkMax.getOutputCurrent());
-
-
+    }
+    
+    public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+      coachTab.addNumber("Extender Temp_C", () -> m_sparkMax.getMotorTemperature());
+      coachTab.addNumber("Extender Current A", () -> m_sparkMax.getOutputCurrent());
     }
 
     public void updateSafetyZones(ArmPose targetArmPose, Rotation2d shoulderAngle){

--- a/src/main/java/frc/robot/subsystems/arm/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/arm/Gripper.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems.arm;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
 import frc.robot.Constants.DebugConstants;
@@ -64,6 +65,12 @@ public class Gripper extends SubsystemBase {
         Robot.logManager.addNumber("Gripper/MotorTemperature_C", DebugConstants.EnableGripperDebug, () -> m_sparkMax.getMotorTemperature());
         Robot.logManager.addBoolean("Gripper/HasPiece", DebugConstants.EnableGripperDebug, () -> hasPiece());
         Robot.logManager.addString("Gripper/Mode", DebugConstants.EnableGripperDebug, () -> getGripperMode().name());
+    }
+    
+    public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+      coachTab.addBoolean("HasPiece?", () -> hasPiece());
+      coachTab.addNumber("Gripper Temp_C", () -> m_sparkMax.getMotorTemperature());
+      coachTab.addNumber("Gripper Current_A", () -> m_sparkMax.getOutputCurrent());
     }
 
     public boolean hasPiece(){

--- a/src/main/java/frc/robot/subsystems/arm/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/arm/Gripper.java
@@ -9,6 +9,7 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.ArmConstants.GripperConstants;
 import frc.robot.util.DashboardNumber;
 // i got the new forgis on the g
@@ -24,7 +25,7 @@ public class Gripper extends SubsystemBase {
 
         private double m_power;
         GripperMode(double power){
-            new DashboardNumber("gripper/speed/" + this.name(), power, (newPower) -> {
+            new DashboardNumber("Gripper/speed/" + this.name(), power, DebugConstants.EnableGripperDebug, (newPower) -> {
                 m_power = newPower;
             });
 
@@ -44,27 +45,28 @@ public class Gripper extends SubsystemBase {
         m_sparkMax = new CANSparkMax(GripperConstants.CanIdGripper, MotorType.kBrushless);
         m_sparkMax.setInverted(false);
         m_sparkMax.setOpenLoopRampRate(0.05);
-        new DashboardNumber("gripper/stallLimit", m_stallLimit, (newValue) -> {
+        new DashboardNumber("Gripper/stallLimit", m_stallLimit, DebugConstants.EnableGripperDebug, (newValue) -> {
             int stallLimit = (int)((double) newValue);
             updateCurrentLimit(stallLimit, m_freeLimit, m_limitRPM);
         });
-        new DashboardNumber("gripper/freeLimit", m_freeLimit, (newValue) -> {
+        new DashboardNumber("Gripper/freeLimit", m_freeLimit, DebugConstants.EnableGripperDebug, (newValue) -> {
             int freeLimit = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, freeLimit, m_limitRPM);
         });
-        new DashboardNumber("gripper/limitRPM", m_limitRPM, (newValue) -> {
+        new DashboardNumber("Gripper/limitRPM", m_limitRPM, DebugConstants.EnableGripperDebug, (newValue) -> {
             int limitRPM = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, m_freeLimit, limitRPM);
         });
         m_sparkMax.burnFlash();
 
-        Robot.logManager.addNumber("Gripper/AppliedOutput", () -> m_sparkMax.getAppliedOutput());
-        Robot.logManager.addNumber("Gripper/OutputCurrent", () -> m_sparkMax.getOutputCurrent());
-        Robot.logManager.addNumber("Gripper/MotorTemperature_C", () -> m_sparkMax.getMotorTemperature());
-        Robot.logManager.addBoolean("Gripper/HasPiece", () -> hasPiece());
+        Robot.logManager.addNumber("Gripper/AppliedOutput", DebugConstants.EnableGripperDebug, () -> m_sparkMax.getAppliedOutput());
+        Robot.logManager.addNumber("Gripper/OutputCurrent", DebugConstants.EnableGripperDebug, () -> m_sparkMax.getOutputCurrent());
+        Robot.logManager.addNumber("Gripper/MotorTemperature_C", DebugConstants.EnableGripperDebug, () -> m_sparkMax.getMotorTemperature());
+        Robot.logManager.addBoolean("Gripper/HasPiece", DebugConstants.EnableGripperDebug, () -> hasPiece());
+        Robot.logManager.addString("Gripper/Mode", DebugConstants.EnableGripperDebug, () -> getGripperMode().name());
     }
 
-    private boolean hasPiece(){
+    public boolean hasPiece(){
         return m_sparkMax.getOutputCurrent() > m_stallLimit - 5;
     }
 

--- a/src/main/java/frc/robot/subsystems/arm/Shoulder.java
+++ b/src/main/java/frc/robot/subsystems/arm/Shoulder.java
@@ -23,6 +23,7 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
@@ -93,6 +94,10 @@ public class Shoulder {
         Robot.logManager.addNumber("Shoulder/target", DebugConstants.EnableArmDebug, () -> m_targetDegrees);
         Robot.logManager.addNumber("Shoulder/Rotation_deg", DebugConstants.EnableArmDebug, () -> getRotation().getDegrees());
         Robot.logManager.addNumber("Shoulder/AngleFromStowed_deg", DebugConstants.EnableArmDebug, () -> getShoulderDegreesFromStowed());
+    }
+    
+    public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+        
     }
 
     public Rotation2d getRotation() {

--- a/src/main/java/frc/robot/subsystems/arm/Shoulder.java
+++ b/src/main/java/frc/robot/subsystems/arm/Shoulder.java
@@ -27,6 +27,7 @@ import edu.wpi.first.wpilibj.simulation.SingleJointedArmSim;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.ArmConstants.ExtenderConstants;
 import frc.robot.Constants.ArmConstants.ShoulderConstants;
 import frc.robot.Constants.ArmConstants.WristConstants;
@@ -84,12 +85,14 @@ public class Shoulder {
             canSparkMax.setSmartCurrentLimit(0, 0, 0);
             //open loop = no pid, closed loop = pid
             canSparkMax.burnFlash();
-            Robot.logManager.addNumber("Shoulder/SparkMax" + canSparkMax.getDeviceId() + "/MotorTemperature_C", () -> canSparkMax.getMotorTemperature());
+            Robot.logManager.addNumber("Shoulder/SparkMax" + canSparkMax.getDeviceId() + "/MotorTemperature_C", DebugConstants.EnableArmDebug, () -> canSparkMax.getMotorTemperature());
 
         }
-        m_pidTuner = new PIDTuner("ShoulderPID", true, 0.025, 0, 1.6, this::tunePID);
+        m_pidTuner = new PIDTuner("Shoulder/PID_Tuner", DebugConstants.EnableArmDebug, 0.025, 0, 1.6, this::tunePID);
         m_SafetyZoneHelper = new SafetyZoneHelper(ShoulderConstants.MinimumAngleDegrees, ShoulderConstants.MaximumAngleDegrees);
-        Robot.logManager.addNumber("Shoulder/target", () -> m_targetDegrees);
+        Robot.logManager.addNumber("Shoulder/target", DebugConstants.EnableArmDebug, () -> m_targetDegrees);
+        Robot.logManager.addNumber("Shoulder/Rotation_deg", DebugConstants.EnableArmDebug, () -> getRotation().getDegrees());
+        Robot.logManager.addNumber("Shoulder/AngleFromStowed_deg", DebugConstants.EnableArmDebug, () -> getShoulderDegreesFromStowed());
     }
 
     public Rotation2d getRotation() {
@@ -97,6 +100,10 @@ public class Shoulder {
             return Rotation2d.fromRadians(m_armSim.getAngleRads());
         }
         return Rotation2d.fromDegrees((m_AbsoluteEncoder.getAbsolutePosition() * ShoulderConstants.AbsoluteAngleConversionFactor) + ShoulderConstants.AbsoluteAngleZeroOffset);
+    }
+
+    public double getShoulderDegreesFromStowed() {
+      return Math.abs(getRotation().plus(Rotation2d.fromDegrees(90)).getDegrees()); 
     }
 
     public Rotation2d getEncoderRotation() {
@@ -165,7 +172,7 @@ public class Shoulder {
        RelativeEncoder encoder = sparkMax.getEncoder();
        encoder.setPositionConversionFactor(ShoulderConstants.SparkMaxEncoderConversionFactor);
        encoder.setPosition(absoluteAngle.getDegrees());
-       Robot.logManager.addNumber("Shoulder/SparkMax" + sparkMax.getDeviceId() + "/TranslatedAngle", ()->encoder.getPosition());
+       Robot.logManager.addNumber("Shoulder/SparkMax" + sparkMax.getDeviceId() + "/TranslatedAngle", DebugConstants.EnableArmDebug, () -> encoder.getPosition());
     }
 
     public boolean atTarget(){

--- a/src/main/java/frc/robot/subsystems/arm/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/arm/Wrist.java
@@ -22,6 +22,7 @@ import frc.robot.Constants.ArmConstants.ShoulderConstants;
 import frc.robot.Constants.ArmConstants.WristConstants;
 import frc.robot.util.DashboardNumber;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /** Add your docs here. */
@@ -83,6 +84,11 @@ public class Wrist {
         Robot.logManager.addNumber("Wrist/OutputCurrent", DebugConstants.EnableArmDebug, () -> m_sparkMax.getOutputCurrent());
         Robot.logManager.addNumber("Wrist/Rotation_deg", DebugConstants.EnableArmDebug, () -> getRotation().getDegrees());
 
+    }
+    
+    public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+      coachTab.addNumber("Wrist Temp_C", () -> m_sparkMax.getMotorTemperature());
+      coachTab.addNumber("Wrist Current_A", () -> m_sparkMax.getOutputCurrent());
     }
 
     private void initializeSparkMaxEncoder(CANSparkMax sparkMax, Rotation2d absoluteAngle) {

--- a/src/main/java/frc/robot/subsystems/arm/Wrist.java
+++ b/src/main/java/frc/robot/subsystems/arm/Wrist.java
@@ -17,6 +17,7 @@ import com.revrobotics.SparkMaxAbsoluteEncoder.Type;
 import java.lang.annotation.Target;
 
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.ArmConstants.ShoulderConstants;
 import frc.robot.Constants.ArmConstants.WristConstants;
 import frc.robot.util.DashboardNumber;
@@ -45,51 +46,52 @@ public class Wrist {
         m_sparkMax.setInverted(false);
         m_sparkMax.setIdleMode(IdleMode.kBrake);
         m_AbsoluteEncoder = m_sparkMax.getAbsoluteEncoder(Type.kDutyCycle); 
-        new DashboardNumber("Wrist/AbsoluteAngleConversionFactor", WristConstants.AbsoluteAngleConversionFactor, (newValue) -> {
+        new DashboardNumber("Wrist/AbsoluteAngleConversionFactor", WristConstants.AbsoluteAngleConversionFactor, DebugConstants.EnableArmDebug, (newValue) -> {
             m_AbsoluteEncoder.setPositionConversionFactor(newValue);
             recalibrateSensors();
             // m_sparkMax.burnFlash();
         });
         m_AbsoluteEncoder.setInverted(false);
-        new DashboardNumber("Wrist/AbsoluteAngleZeroOffset", WristConstants.AbsoluteAngleZeroOffset, (newOffset) -> {
+        new DashboardNumber("Wrist/AbsoluteAngleZeroOffset", WristConstants.AbsoluteAngleZeroOffset, DebugConstants.EnableArmDebug, (newOffset) -> {
             m_AbsoluteEncoder.setZeroOffset(newOffset);
             recalibrateSensors();
             // m_sparkMax.burnFlash();
         });
-        m_pidTuner = new PIDTuner("WristPID", true, 0.02, 0, 1.0, this::tunePID);
+        m_pidTuner = new PIDTuner("Wrist/PID_Tuner", DebugConstants.EnableArmDebug, 0.02, 0, 1.0, this::tunePID);
         m_SafetyZoneHelper = new SafetyZoneHelper(WristConstants.MinimumAngle, WristConstants.MaximumAngle);
         initializeSparkMaxEncoder(m_sparkMax, getRotation());
         m_AbsoluteEncoder.setInverted(false);
-        new DashboardNumber("Wrist/RampUprate", WristConstants.RampUpRate, (newValue) -> {
+        new DashboardNumber("Wrist/RampUprate", WristConstants.RampUpRate, DebugConstants.EnableArmDebug, (newValue) -> {
             m_sparkMax.setOpenLoopRampRate(newValue);
             m_sparkMax.setClosedLoopRampRate(newValue);
         });
-        new DashboardNumber("wrist/stallLimit", m_stallLimit, (newValue) -> {
+        new DashboardNumber("Wrist/stallLimit", m_stallLimit, DebugConstants.EnableArmDebug, (newValue) -> {
             int stallLimit = (int)((double) newValue);
             updateCurrentLimit(stallLimit, m_freeLimit, m_limitRPM);
         });
-        new DashboardNumber("wrist/freeLimit", m_freeLimit, (newValue) -> {
+        new DashboardNumber("Wrist/freeLimit", m_freeLimit, DebugConstants.EnableArmDebug, (newValue) -> {
             int freeLimit = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, freeLimit, m_limitRPM);
         });
-        new DashboardNumber("wrist/limitRPM", m_limitRPM, (newValue) -> {
+        new DashboardNumber("Wrist/limitRPM", m_limitRPM, DebugConstants.EnableArmDebug, (newValue) -> {
             int limitRPM = (int)((double) newValue);
             updateCurrentLimit(m_stallLimit, m_freeLimit, limitRPM);
         });
         m_sparkMax.burnFlash();
-        Robot.logManager.addNumber("Wrist/AppliedOutput", () -> m_sparkMax.getAppliedOutput());
-        Robot.logManager.addNumber("Wrist/MotorTemperature_C", () -> m_sparkMax.getMotorTemperature());
-        Robot.logManager.addNumber("Wrist/OutputCurrent", () -> m_sparkMax.getOutputCurrent());
+        Robot.logManager.addNumber("Wrist/AppliedOutput", DebugConstants.EnableArmDebug, () -> m_sparkMax.getAppliedOutput());
+        Robot.logManager.addNumber("Wrist/MotorTemperature_C", DebugConstants.EnableArmDebug, () -> m_sparkMax.getMotorTemperature());
+        Robot.logManager.addNumber("Wrist/OutputCurrent", DebugConstants.EnableArmDebug, () -> m_sparkMax.getOutputCurrent());
+        Robot.logManager.addNumber("Wrist/Rotation_deg", DebugConstants.EnableArmDebug, () -> getRotation().getDegrees());
 
     }
 
     private void initializeSparkMaxEncoder(CANSparkMax sparkMax, Rotation2d absoluteAngle) {
         RelativeEncoder encoder = sparkMax.getEncoder();
-        new DashboardNumber("Wrist/EncoderConversionFactor", WristConstants.SparkMaxEncoderConversionFactor, (newConversionFactor) -> {
+        new DashboardNumber("Wrist/EncoderConversionFactor", WristConstants.SparkMaxEncoderConversionFactor, DebugConstants.EnableArmDebug, (newConversionFactor) -> {
             encoder.setPositionConversionFactor(newConversionFactor);
             recalibrateSensors();
         });
-        Robot.logManager.addNumber("Wrist/EncoderRotation", () -> encoder.getPosition());
+        Robot.logManager.addNumber("Wrist/EncoderRotation", DebugConstants.EnableArmDebug, () -> encoder.getPosition());
         
     }
 

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
@@ -26,6 +26,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.SwerveConstants;
 import frc.robot.commands.RecalibrateModules;
 import frc.robot.logging.LogManager;
@@ -54,7 +55,7 @@ public class SwerveDrive extends SubsystemBase {
   private PIDTuner m_AnglePidTuner;
   private PIDTuner m_moduleVelocityPIDTuner;
   private PIDTuner m_moduleAnglePIDTuner;
-  private double m_driveToTargetTolerance = Constants.DriveToTargetTolerance;
+  private double m_driveToTargetTolerance = SwerveConstants.DriveToTargetTolerance;
   
   private Limelight m_limelightLeft;
   private Limelight m_limelightRight;
@@ -105,30 +106,35 @@ public class SwerveDrive extends SubsystemBase {
         getModulePositions());
     resetPose(new Pose2d(8, 4, Rotation2d.fromDegrees(0)));
     m_field = new Field2d();
-    SmartDashboard.putData("SwerveDrive", m_field);
+    if (DebugConstants.EnableDriveDebug) {
+      SmartDashboard.putData("SwerveDrive", m_field);
+    }
     m_XPid = new PIDController(0.6, 0.05, 0.1);
     m_YPid = new PIDController(0.6, 0.05, 0.1);
     m_AnglePid = new PIDController(0.8, 0.01, 0.08);
     m_AnglePid.enableContinuousInput(-Math.PI, Math.PI);
-    m_XPidTuner = new PIDTuner("X PID Tuner", true, m_XPid);
-    m_YPidTuner = new PIDTuner("Y PID Tuner", true, m_YPid);
-    m_XPid.setTolerance(Constants.DriveToTargetTolerance);
-    m_YPid.setTolerance(Constants.DriveToTargetTolerance);
-    m_AnglePid.setTolerance(Constants.AnglePIDTolerance);
-    m_AnglePidTuner = new PIDTuner("Angle PID Tuner", true, m_AnglePid);
-    Robot.logManager.addNumber("SwerveDrive/X_m", () -> m_odometry.getPoseMeters().getX());
-    Robot.logManager.addNumber("SwerveDrive/Y_m", () -> m_odometry.getPoseMeters().getY());
-    Robot.logManager.addNumber("SwerveDrive/Rotation_deg", () -> getOdometryRotation().getDegrees());
+    m_XPidTuner = new PIDTuner("SwerveDrive/X_PID_Tuner", DebugConstants.EnableDriveDebug, m_XPid);
+    m_YPidTuner = new PIDTuner("SwerveDrive/Y_PID_Tuner", DebugConstants.EnableDriveDebug, m_YPid);
+    m_XPid.setTolerance(SwerveConstants.DriveToTargetTolerance);
+    m_YPid.setTolerance(SwerveConstants.DriveToTargetTolerance);
+    m_AnglePid.setTolerance(SwerveConstants.AnglePIDTolerance);
+    m_AnglePidTuner = new PIDTuner("SwerveDrive/Angle_PID_Tuner", DebugConstants.EnableDriveDebug, m_AnglePid);
+    Robot.logManager.addNumber("SwerveDrive/X_m", DebugConstants.EnableDriveDebug, () -> m_odometry.getPoseMeters().getX());
+    Robot.logManager.addNumber("SwerveDrive/Y_m", DebugConstants.EnableDriveDebug, () -> m_odometry.getPoseMeters().getY());
+    Robot.logManager.addNumber("SwerveDrive/Rotation_deg", DebugConstants.EnableDriveDebug, () -> getOdometryRotation().getDegrees());
+    Robot.logManager.addNumber("SwerveDrive/Gyro_angle_deg", DebugConstants.EnableDriveDebug, () -> getGyroRotation().getDegrees());
+    Robot.logManager.addNumber("SwerveDrive/Gyro_pitch_deg", DebugConstants.EnableDriveDebug, () -> getPitch().getDegrees());
+    Robot.logManager.addNumber("SwerveDrive/Gyro_roll_deg", DebugConstants.EnableDriveDebug, () -> getRoll().getDegrees());
     double velocityP = 0.1;
     double velocityI = 0;
     double velocityD = 0;
     double velocityF = 0.054;
     // `this::updateVelocityPIDConstants` is basically shorthand for `(PIDUpdate update) -> updateVelocityPIDConstants(update)`
-    m_moduleVelocityPIDTuner = new PIDTuner("Swerve/ModuleVelocity", false, velocityP, velocityI, velocityD, velocityF, this::updateVelocityPIDConstants);
+    m_moduleVelocityPIDTuner = new PIDTuner("Swerve/ModuleVelocity_PID_Tuner", DebugConstants.EnableDriveDebug, velocityP, velocityI, velocityD, velocityF, this::updateVelocityPIDConstants);
     double angleP = 0.2;
     double angleI = 0;
     double angleD = 0;
-    m_moduleAnglePIDTuner = new PIDTuner("Swerve/ModuleAngle", false, angleP, angleI, angleD, this::updateAnglePIDConstants);
+    m_moduleAnglePIDTuner = new PIDTuner("Swerve/ModuleAngle_PID_Tuner", DebugConstants.EnableDriveDebug, angleP, angleI, angleD, this::updateAnglePIDConstants);
 
   }
 
@@ -174,13 +180,9 @@ public class SwerveDrive extends SubsystemBase {
   }
 
   public void move(ChassisSpeeds chassisSpeeds) {
-    SmartDashboard.putNumber("Swerve/x_input", chassisSpeeds.vxMetersPerSecond);
-    SmartDashboard.putNumber("Swerve/y_input", chassisSpeeds.vyMetersPerSecond);
     chassisSpeeds.vxMetersPerSecond = MathUtil.clamp(chassisSpeeds.vxMetersPerSecond, -1, 1) * SwerveConstants.MaxRobotSpeed_mps * SpeedModifier;
     chassisSpeeds.vyMetersPerSecond = MathUtil.clamp(chassisSpeeds.vyMetersPerSecond, -1, 1)* SwerveConstants.MaxRobotSpeed_mps * SpeedModifier;
     chassisSpeeds.omegaRadiansPerSecond = MathUtil.clamp(chassisSpeeds.omegaRadiansPerSecond, -1, 1) * SwerveConstants.MaxRobotRotation_radps * SpeedModifier;
-    SmartDashboard.putNumber("Swerve/x_output", chassisSpeeds.vxMetersPerSecond);
-    SmartDashboard.putNumber("Swerve/y_output", chassisSpeeds.vyMetersPerSecond);
     if (chassisSpeeds.vxMetersPerSecond == 0 && chassisSpeeds.vyMetersPerSecond == 0 && chassisSpeeds.omegaRadiansPerSecond == 0) {
       stop();
       return;
@@ -247,7 +249,7 @@ public class SwerveDrive extends SubsystemBase {
     m_XPid.reset();
     m_YPid.reset();
     m_AnglePid.reset();
-    setDriveTranslationTolerance(Constants.DriveToTargetTolerance);
+    setDriveTranslationTolerance(SwerveConstants.DriveToTargetTolerance);
   }
 
   public boolean atTarget() {
@@ -310,25 +312,20 @@ public class SwerveDrive extends SubsystemBase {
       m_simrotation = m_simrotation.plus(Rotation2d.fromRadians(radians));
     }
     Pose2d robotPose = m_odometry.update(getGyroRotation(), getModulePositions());
-    SmartDashboard.putNumber("SwerveDrive/X", robotPose.getX());
-    SmartDashboard.putNumber("SwerveDrive/y", robotPose.getY());
-    SmartDashboard.putNumber("SwerveDrive/Rotation", robotPose.getRotation().getDegrees());
     m_field.setRobotPose(robotPose);
     updateModuleOnField(m_frontLeft, robotPose, "FL");
     updateModuleOnField(m_frontRight, robotPose, "FR");
     updateModuleOnField(m_backLeft, robotPose, "BL");
     updateModuleOnField(m_backRight, robotPose, "BR");
-    SmartDashboard.putNumber("gyro_angle", getGyroRotation().getDegrees());
-    SmartDashboard.putNumber("gyro_pitch", GetPitch().getDegrees());
     m_XPidTuner.tune();
     m_YPidTuner.tune();
     m_AnglePidTuner.tune();
     m_moduleVelocityPIDTuner.tune();
     m_moduleAnglePIDTuner.tune();
-    m_frontLeft.getModuleInfo();
-    m_frontRight.getModuleInfo();
-    m_backLeft.getModuleInfo();
-    m_backRight.getModuleInfo();
+    m_frontLeft.updateDashboard();
+    m_frontRight.updateDashboard();
+    m_backLeft.updateDashboard();
+    m_backRight.updateDashboard();
   }
 
   public void resetPose(Pose2d targetPose){
@@ -395,8 +392,12 @@ public class SwerveDrive extends SubsystemBase {
     }
   }
 
-  public Rotation2d GetPitch() {
+  public Rotation2d getPitch() {
     return Rotation2d.fromDegrees(m_gyro.getPitch());
+  }
+
+  public Rotation2d getRoll() {
+    return Rotation2d.fromDegrees(m_gyro.getRoll());
   }
 }
 // “I love polyester.” -Kenny

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveDrive.java
@@ -21,6 +21,7 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SPI;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -106,9 +107,7 @@ public class SwerveDrive extends SubsystemBase {
         getModulePositions());
     resetPose(new Pose2d(8, 4, Rotation2d.fromDegrees(0)));
     m_field = new Field2d();
-    if (DebugConstants.EnableDriveDebug) {
-      SmartDashboard.putData("SwerveDrive", m_field);
-    }
+    SmartDashboard.putData("SwerveDrive", m_field);
     m_XPid = new PIDController(0.6, 0.05, 0.1);
     m_YPid = new PIDController(0.6, 0.05, 0.1);
     m_AnglePid = new PIDController(0.8, 0.01, 0.08);
@@ -136,6 +135,13 @@ public class SwerveDrive extends SubsystemBase {
     double angleD = 0;
     m_moduleAnglePIDTuner = new PIDTuner("Swerve/ModuleAngle_PID_Tuner", DebugConstants.EnableDriveDebug, angleP, angleI, angleD, this::updateAnglePIDConstants);
 
+  }
+    
+  public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+    m_frontLeft.addCoachTabDashboardValues(coachTab);
+    m_frontRight.addCoachTabDashboardValues(coachTab);
+    m_backLeft.addCoachTabDashboardValues(coachTab);
+    m_backRight.addCoachTabDashboardValues(coachTab);
   }
 
   public void driverModeInit() {
@@ -342,6 +348,9 @@ public class SwerveDrive extends SubsystemBase {
   }
 
   public void updateModuleOnField(SwerveModule swerveModule, Pose2d robotPose, String name) {
+    if (!DebugConstants.EnableDriveDebug) {
+      return;
+    }
     Transform2d transform = new Transform2d(swerveModule.getTranslation().times(5), swerveModule.getModuleState().angle);
     Pose2d swerveModulePose = robotPose.transformBy(transform);
     m_field.getObject(name).setPose(swerveModulePose);

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
@@ -17,6 +17,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
 import frc.robot.Robot;
@@ -58,6 +59,10 @@ public abstract class SwerveModule {
     Robot.logManager.addNumber(getDSKey("Velocity_Temp_C"), DebugConstants.EnableDriveDebug, () -> m_velocity.getTemperature());
     Robot.logManager.addNumber(getDSKey("Angle_Temp_C"), DebugConstants.EnableDriveDebug, () -> m_angle.getTemperature());
 
+  }
+    
+  public void addCoachTabDashboardValues(ShuffleboardTab coachTab) {
+    
   }
 
   public void driverModeInit() {

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule.java
@@ -20,6 +20,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
 import frc.robot.Robot;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.util.DashboardNumber;
 
 public abstract class SwerveModule {
@@ -31,8 +32,8 @@ public abstract class SwerveModule {
   private double initialEncoder;
   private String m_name;
 
-  private static DashboardNumber VelocityRampRateDriver = new DashboardNumber("Swerve/VelocityRampRateDriver", 1, (newValue) -> {});
-  private static DashboardNumber VelocityRampRateAuto = new DashboardNumber("Swerve/VelocityRampRateAuto", 0.25, (newValue) -> {});
+  private static DashboardNumber VelocityRampRateDriver = new DashboardNumber("Swerve/VelocityRampRateDriver", 1, DebugConstants.EnableDriveDebug, (newValue) -> {});
+  private static DashboardNumber VelocityRampRateAuto = new DashboardNumber("Swerve/VelocityRampRateAuto", 0.25, DebugConstants.EnableDriveDebug, (newValue) -> {});
 
   /** Creates a new SwerveModule. */
   public SwerveModule(String name, Translation2d translation, int canIdAngle, int canIdVelocity) {
@@ -53,6 +54,9 @@ public abstract class SwerveModule {
 
     m_velocity.configClosedloopRamp(VelocityRampRateDriver.get());
     m_angle.configClosedloopRamp(0);
+
+    Robot.logManager.addNumber(getDSKey("Velocity_Temp_C"), DebugConstants.EnableDriveDebug, () -> m_velocity.getTemperature());
+    Robot.logManager.addNumber(getDSKey("Angle_Temp_C"), DebugConstants.EnableDriveDebug, () -> m_angle.getTemperature());
 
   }
 
@@ -130,16 +134,18 @@ public abstract class SwerveModule {
     return "Swerve Module " + m_name + "/" + field;
   }
 
-  public void getModuleInfo() {
-    SmartDashboard.putNumber(getDSKey("Angle"), getModuleState().angle.getDegrees());
-    SmartDashboard.putNumber(getDSKey("Speed"), getModuleState().speedMetersPerSecond);
-    // SmartDashboard.putNumber(getDSKey("VelocityEncoderPosition"), m_velocity.getSelectedSensorPosition());
-    // SmartDashboard.putNumber(getDSKey("AngleEncoder"), m_angle.getSelectedSensorPosition());
-    // SmartDashboard.putNumber(getDSKey("Position"), getPosition().distanceMeters);
-    // SmartDashboard.putNumber(getDSKey("VelocityEncoderVelocity"), m_velocity.getSelectedSensorVelocity());
-    SmartDashboard.putNumber(getDSKey("AbsoluteAngle"), getAbsoluteAngle());
-    // SmartDashboard.putNumber(getDSKey("InitialEncoder"), initialEncoder);
-    // SmartDashboard.putNumber(getDSKey("AbsoluteEncoder"), getRawAbsoluteAngle());
+  public void updateDashboard() {
+    if (DebugConstants.EnableDriveDebug) {
+      SmartDashboard.putNumber(getDSKey("Angle"), getModuleState().angle.getDegrees());
+      SmartDashboard.putNumber(getDSKey("Speed"), getModuleState().speedMetersPerSecond);
+      // SmartDashboard.putNumber(getDSKey("VelocityEncoderPosition"), m_velocity.getSelectedSensorPosition());
+      // SmartDashboard.putNumber(getDSKey("AngleEncoder"), m_angle.getSelectedSensorPosition());
+      // SmartDashboard.putNumber(getDSKey("Position"), getPosition().distanceMeters);
+      // SmartDashboard.putNumber(getDSKey("VelocityEncoderVelocity"), m_velocity.getSelectedSensorVelocity());
+      SmartDashboard.putNumber(getDSKey("AbsoluteAngle"), getAbsoluteAngle());
+      // SmartDashboard.putNumber(getDSKey("InitialEncoder"), initialEncoder);
+      // SmartDashboard.putNumber(getDSKey("AbsoluteEncoder"), getRawAbsoluteAngle());
+    }
   }
 
   public double encoderToDegrees(double counts) {

--- a/src/main/java/frc/robot/subsystems/swerve/SwerveModule2023.java
+++ b/src/main/java/frc/robot/subsystems/swerve/SwerveModule2023.java
@@ -7,6 +7,7 @@ package frc.robot.subsystems.swerve;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.AnalogEncoder;
+import frc.robot.Constants.DebugConstants;
 import frc.robot.Constants.SwerveConstants;
 import frc.robot.util.DashboardNumber;
 
@@ -20,7 +21,7 @@ public class SwerveModule2023 extends SwerveModule {
 
         m_absoluteEncoder = new AnalogEncoder(absoluteAnalogPort);
 
-        new DashboardNumber(getDSKey("absoluteAngleOffset"), absoluteAngleOffset, (newValue) -> {
+        new DashboardNumber(getDSKey("absoluteAngleOffset"), absoluteAngleOffset, DebugConstants.EnableDriveDebug,  (newValue) -> {
             m_absoluteAngleOffset = newValue;
             recalibrate();
         });

--- a/src/main/java/frc/robot/util/DashboardNumber.java
+++ b/src/main/java/frc/robot/util/DashboardNumber.java
@@ -14,20 +14,21 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /** Add your docs here. */
 public class DashboardNumber {
-    public static boolean Enabled = true;
     private static Set<String> ChangedValues = new HashSet<>();
     private static List<DashboardNumber> AllUpdaters = new ArrayList<>();
 
     private double m_value;
     private String m_name;
     private Consumer<Double> m_onUpdate;
+    private boolean m_tuningEnabled;
     
-    public DashboardNumber(String name, double startValue, Consumer<Double> onUpdate) {
+    public DashboardNumber(String name, double startValue, boolean tuningEnabled, Consumer<Double> onUpdate) {
         m_value = startValue;
         m_name = name;
         m_onUpdate = onUpdate;
+        m_tuningEnabled = tuningEnabled;
         onUpdate.accept(m_value);
-        if(Enabled) {
+        if(m_tuningEnabled) {
             SmartDashboard.putNumber(name, m_value);
         }
         AllUpdaters.add(this);
@@ -38,6 +39,9 @@ public class DashboardNumber {
     }
 
     private void checkValue() {
+        if(!m_tuningEnabled) {
+            return;
+        }
         var newValue = SmartDashboard.getNumber(m_name, m_value);
         if(newValue != m_value) {
             m_value = newValue;
@@ -47,9 +51,6 @@ public class DashboardNumber {
     }
 
     public static void checkAll() {
-        if(!Enabled) {
-            return;
-        }
         for (DashboardNumber dashboardNumber : AllUpdaters) {
             dashboardNumber.checkValue();
         }


### PR DESCRIPTION
This disables most values from being logged to the dashboard. 
The values can be re-enabled by changing the settings in DebugConstants (Drive, Arm, and Gripper can be toggled individually)

Important values are still logged to the flashdrive in a CSV. 
All Motor Temp Values are logged there. 

Also adds a 'Coach" tab to the shuffleborard, where all the values that Dan wants to make sure are on the dashboard are always there. 
And value Dan (or alternative coach/drive team members) want, should go inside that function in RobotContainer. 